### PR TITLE
fix(): typo leading to syntax error in install script

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -324,8 +324,7 @@ SQLITE_PATH="data/reconya-dev.db"
 
     // Install Go dependencies
     Utils.log.info('Installing Go dependencies...');
-    const backendPath = path.join(projectRoot, 'backend');
-    
+
     // Verify Go is available
     if (!Utils.commandExists('go')) {
       throw new Error('Go not found in PATH. Please install Go and ensure it is in your PATH.');


### PR DESCRIPTION
Simple syntax error in the install script:

```
$ npm run install

> reconya@1.0.0 install
> cd scripts && npm install && node install.js


> reconya-scripts@1.0.0 install
> node install.js

/Users/ts/Downloads/reconya/scripts/install.js:327
    const backendPath = path.join(projectRoot, 'backend');
          ^

SyntaxError: Identifier 'backendPath' has already been declared
    at wrapSafe (node:internal/modules/cjs/loader:1469:18)
    at Module._compile (node:internal/modules/cjs/loader:1491:20)
    at Object..js (node:internal/modules/cjs/loader:1689:10)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
    at Function._load (node:internal/modules/cjs/loader:1128:12)
    at TracingChannel.traceSync (node:diagnostics_channel:315:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:218:24)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:170:5)
    at node:internal/main/run_main_module:36:49

```