### PR TITLE
Fix systems with no lsof

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -165,7 +165,7 @@ class Installer {
 
     // Install basic tools
     await Utils.runCommand('sudo', ['apt-get', 'install', '-y', 
-      'curl', 'wget', 'software-properties-common', 'apt-transport-https'
+      'curl', 'wget', 'software-properties-common', 'apt-transport-https', 'lsof'
     ]);
 
     // Install Go


### PR DESCRIPTION
Some systems don't have `lsof` installed by default, eg: RaspberryPi with Debian Bookworm. Add `lsof` to list of basic tools.