### PR TITLE
Support multiple CIDR ranges per network

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,159 @@
+# reconYa - Developer Guide
+
+This documentation is designed for AI assistants and developers working with the reconYa codebase. For user-facing documentation, see [README.md](README.md). For contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+---
+
+## Quick Start
+
+reconYa is a self-hosted network reconnaissance and asset discovery tool: it sweeps a local subnet, fingerprints what answers, and keeps a live console (topology map, device list, alerts, event log) of the result.
+
+**Tech Stack:** Go 1.25 backend (`net/http` + gorilla/mux), server-rendered HTML + HTMX + vanilla JS frontend, SQLite (embedded, no separate DB server)
+
+**Get Started:**
+```bash
+git clone https://github.com/Dyneteq/reconya.git
+cd reconya
+make install
+make start-dev   # http://localhost:3008, default login admin / password
+```
+
+---
+
+## Documentation Index
+
+1. **[Architecture Overview](docs/architecture.md)**
+   - Tech stack, request flow, background workers
+   - Data model hierarchy
+   - Authentication
+   - Network isolation (outbound calls are opt-in only)
+
+2. **[Directory Structure](docs/directory-structure.md)**
+   - Full tree of git-tracked paths
+   - What `src/`, `reconya/`, `oui/`, `data/` are (gitignored local runtime artifacts, not source)
+   - Critical paths quick reference
+
+3. **[Backend Patterns](docs/backend-patterns.md)**
+   - Module architecture (`backend/internal/<name>/`)
+   - How to add a new module
+   - Repository pattern
+   - Alert rules pattern (pure functions vs. I/O)
+   - Web handler and HTMX/frontend patterns
+
+4. **[Database](docs/database.md)**
+   - SQLite only, no migration files, schema evolves via idempotent `CREATE TABLE IF NOT EXISTS` / `ALTER TABLE ADD COLUMN`
+   - Table reference
+   - Alerts upsert/dedupe pattern
+
+5. **[Development Workflow](docs/development-workflow.md)**
+   - Setup, `make start-dev`, environment variables
+   - Adding a feature end-to-end
+   - Building and releasing (`make release V=x.y.z`)
+
+6. **[Code Conventions](docs/code-conventions.md)**
+   - Go style, error wrapping, naming
+   - Why some models still carry `bson` tags
+   - API and frontend conventions
+
+7. **[Testing](docs/testing.md)**
+   - Colocated unit tests vs. `backend/tests/integration/`
+   - Real-SQLite test database via `testutils.SetupTestDatabase`
+   - Running `go test ./...`
+
+8. **[Common Tasks](docs/common-tasks.md)**
+   - Add a column / table, new module, new API endpoint, new alert rule, new page, new config var
+   - Fix a bug, cut a release
+
+9. **[Claude Memory & Preferences](docs/MEMORY.md)**
+   - Commit message conventions (no `Co-authored-by`, no em dashes, no emoji)
+   - Scope boundaries (no cloud/SaaS, outbound calls opt-in by default)
+   - Patterns to remember (no migrations, vestigial `bson` tags, pure alert rules)
+
+### Feature Behavior
+
+10. **[Network Scanning](docs/00-network-scanning.md)**
+    - Ping sweep algorithm (ICMP/ARP/TCP corroboration rule), continuous 30s scan loop
+    - Primary NIC detection and network auto-suggestion (never auto-creates)
+    - IPv6 passive monitoring, and where its documented env vars don't actually wire up
+
+11. **[Device Identification & Fingerprinting](docs/01-device-identification.md)**
+    - Vendor lookup (two separate paths; the bundled IEEE OUI database is dead code)
+    - Hostname resolution methods, device-type classification heuristics
+    - New-vs-update matching (`CreateOrUpdateWithDelta`), why the delta exists
+
+12. **[Port Scanning & Web Services](docs/02-port-scanning.md)**
+    - Fixed 89-port list, replace-all port storage, 30s cooldown
+    - Web service detection and the screenshot fallback chain
+    - The screenshots-enabled setting doesn't actually control scan behavior (yet)
+
+13. **[Alerting](docs/03-alerting.md)**
+    - Each rule's exact trigger condition (unidentified host, duplicate MAC, risky port, host unreachable)
+    - Dedupe/upsert mechanics, ack semantics, one-shot expiry
+    - When evaluation runs (1-minute ticker + after every sweep)
+
+14. **[Web Console](docs/04-web-console.md)**
+    - Single-template-many-pages rendering mechanism
+    - Per-page behavior: dashboard/topology, devices, networks, logs, alerts, settings
+    - Polling cadence, and the missing client-side 401/session-expiry handling
+
+---
+
+## Project Overview
+
+**Core Capabilities:**
+- IPv4 network scanning (native Go ICMP/TCP/ARP), IPv6 passive monitoring (no traffic generated)
+- Device identification: MAC/vendor, hostname, OS fingerprint, device type
+- Background port scanning with service/banner detection
+- Alerting: new devices, new/risky open ports, unreachable hosts, duplicate MACs, unidentified hosts
+- Server-rendered web console: topology map, host list, live event log
+- Multi-network support (multiple CIDRs)
+- Zero outbound calls by default, every third-party lookup is an explicit opt-in flag
+
+**Target Users:** Network administrators, security professionals, home users monitoring their own LAN.
+
+---
+
+## Technology Stack
+
+**Backend:**
+- Go 1.25, `net/http` + `gorilla/mux`
+- SQLite via `mattn/go-sqlite3` (cgo, WAL mode)
+- `gorilla/sessions` (cookie sessions), `joho/godotenv` (.env loading)
+- Optional `chromedp` build tag for in-process screenshots (off by default; falls back to a system browser/tool)
+
+**Frontend:**
+- `html/template` (embedded via `//go:embed`), HTMX, vanilla JS (no bundler, no framework)
+
+**Testing:**
+- `testing` + `testify`, real-SQLite integration tests (no mocking framework)
+
+---
+
+## Critical Paths Quick Reference
+
+| Task | Location |
+|---|---|
+| Add a domain feature | `backend/internal/<feature>/` |
+| Add/modify a route | `backend/internal/web/router.go` + `handlers.go` |
+| Change the DB schema | `backend/db/sqlite.go` (`InitializeSchema`) |
+| Add a repository method | `backend/db/repository.go` (interface) + `sqlite_repositories.go` (impl) |
+| Wire a new service | `backend/cmd/main.go` |
+| Console frontend | `backend/assets/templates/`, `backend/assets/static/{css,js}/` |
+| Add an env-configurable setting | `backend/internal/config/config.go` |
+| Tests | `backend/tests/integration/` or colocated `_test.go` |
+
+---
+
+## Related Documentation
+
+| Document | Audience | Purpose |
+|---|---|---|
+| [README.md](README.md) | Users | Features, installation, configuration, usage |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contributors | PR workflow, coding standards |
+| **CLAUDE.md** | Developers, AI | Codebase architecture, patterns (this file) |
+
+---
+
+**Document Version:** 1.0.0
+**Last Updated:** 2026-08-11
+**Maintainer:** Update when architecture changes or patterns evolve

--- a/backend/assets/static/css/console.css
+++ b/backend/assets/static/css/console.css
@@ -658,6 +658,51 @@ textarea::placeholder {
     white-space: nowrap;
 }
 
+.rc-segments {
+    padding: 12px 12px 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.rc-segment {
+    flex: 1 1 auto;
+    min-width: 46px;
+    padding: 5px 7px;
+    background: var(--rc-wash);
+    border: 1px solid var(--rc-line-14);
+    border-left: 2px solid var(--rc-line-40);
+    cursor: pointer;
+    font-size: 10px;
+}
+
+.rc-segment:hover {
+    background: var(--rc-wash-hi);
+}
+
+.rc-segment.is-active {
+    background: var(--rc-wash-hi);
+    border-left-color: var(--rc-accent);
+}
+
+.rc-segment.is-inactive {
+    opacity: 0.45;
+}
+
+.rc-segment__cidr {
+    display: block;
+    color: var(--rc-text-2);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.rc-segment__count {
+    display: block;
+    color: var(--rc-text-5);
+    margin-top: 2px;
+}
+
 .rc-subnets {
     padding: 12px;
     display: flex;

--- a/backend/assets/static/js/console.js
+++ b/backend/assets/static/js/console.js
@@ -48,10 +48,20 @@
         pingInternet();
         window.RCSuggestions.init();
 
+        if (isMap) {
+            window.RCSegments.load().then(renderSubnetsFromState);
+            window.RCSegments.onScopeChange(function () {
+                renderDock(window.RCDevices.state());
+            });
+        }
+
         every(POLL.devices, function () { window.RCDevices.load(); });
         every(POLL.scan, function () { window.RCScan.poll(); });
         every(POLL.alerts, function () { window.RCAlerts.load(); });
         every(POLL.metrics, loadMetrics);
+        every(POLL.metrics, function () {
+            if (isMap) window.RCSegments.load().then(renderSubnetsFromState);
+        });
         every(POLL.ping, pingInternet);
 
         if (isMap) startMapView();
@@ -166,7 +176,8 @@
         if (isMap) {
             window.RCMap.setData(state.devices, state.networks);
             renderDock(state);
-            renderSubnets(state);
+            window.RCSegments.render();
+            renderSubnetsFromState(state);
         }
         if (page === 'devices') renderHostsPage(state);
     }
@@ -184,6 +195,7 @@
         bindMapControls();
         bindDock();
         bindFeedTabs();
+        bindScanPlan();
 
         loadEvents();
         every(POLL.events, loadEvents);
@@ -258,47 +270,73 @@
         if (zoomFit) zoomFit.addEventListener('click', function () { window.RCMap.fit(); });
     }
 
-    // Per-network online/known, the honest version of the design's "SUBNET LOAD"
-    // panel: known hosts rather than allocated addresses, because that is what
-    // the scanner records.
-    function renderSubnets(state) {
+    // The SCAN PLAN list: one row per range (not per network — a network can
+    // own several), showing known/online hosts against the range's real
+    // address capacity and a running total across all active ranges. Each row
+    // toggles the range in or out of future scans.
+    function renderSubnetsFromState(state) {
         var container = RC.el('rc-subnets');
         if (!container) return;
 
-        var byNetwork = {};
-        state.devices.forEach(function (d) {
-            var key = d.network_id || 'unassigned';
-            if (!byNetwork[key]) byNetwork[key] = { total: 0, online: 0 };
-            byNetwork[key].total++;
-            if ((d.status || '').toLowerCase() === 'online') byNetwork[key].online++;
-        });
+        var byIP = {};
+        (state.devices || []).forEach(function (d) { byIP[d.ipv4] = d; });
 
-        var rows = Object.keys(byNetwork).map(function (key) {
-            var stat = byNetwork[key];
-            var pct = stat.total ? Math.round((stat.online / stat.total) * 100) : 0;
-            var color = pct >= 80 ? 'var(--rc-accent)'
-                : (pct >= 50 ? 'rgba(74,222,128,.6)' : 'var(--rc-amber)');
+        var runningTotal = 0;
+        var rows = [];
 
-            return '<div>' +
-                '<div class="rc-subnet__row">' +
-                    '<span class="rc-subnet__name">' + RC.esc(state.networks[key] || 'unassigned') + '</span>' +
-                    '<span class="rc-subnet__count">' + stat.online + ' / ' + stat.total + '</span>' +
-                '</div>' +
-                '<div class="rc-subnet__track"><div class="rc-subnet__fill" style="width:' +
-                    pct + '%;background:' + color + '"></div></div>' +
-                '</div>';
+        window.RCSegments.networks().forEach(function (n) {
+            (n.ranges || []).forEach(function (r) {
+                var known = 0, online = 0;
+                Object.keys(byIP).forEach(function (ip) {
+                    if (!RC.ipInCidr(ip, r.cidr)) return;
+                    known++;
+                    if ((byIP[ip].status || '').toLowerCase() === 'online') online++;
+                });
+
+                var capacity = RC.cidrSize(r.cidr);
+                if (r.active) runningTotal += capacity;
+
+                var pct = capacity ? Math.round((known / capacity) * 100) : 0;
+                var color = !r.active ? 'var(--rc-text-5)'
+                    : (pct >= 60 ? 'var(--rc-accent)' : (pct >= 20 ? 'rgba(74,222,128,.6)' : 'var(--rc-amber)'));
+
+                rows.push('<div data-network-id="' + RC.esc(n.id) + '" data-range-id="' + RC.esc(r.id) +
+                        '" style="cursor:pointer' + (r.active ? '' : ';opacity:.45') + '" title="click to ' +
+                        (r.active ? 'exclude from' : 'include in') + ' scans">' +
+                    '<div class="rc-subnet__row">' +
+                        '<span class="rc-subnet__name">' + RC.esc(r.label || r.cidr) + '</span>' +
+                        '<span class="rc-subnet__count">' + known + ' known / ' + capacity + '</span>' +
+                    '</div>' +
+                    '<div class="rc-subnet__track"><div class="rc-subnet__fill" style="width:' +
+                        pct + '%;background:' + color + '"></div></div>' +
+                    '</div>');
+            });
         });
 
         RC.render(container, rows.length
-            ? rows.join('')
-            : '<div style="font-size:11px;color:var(--rc-text-5)">No hosts discovered yet</div>');
+            ? rows.join('') + '<div style="font-size:10px;color:var(--rc-text-5);padding-top:4px">' +
+                runningTotal + ' addresses in active scan plan</div>'
+            : '<div style="font-size:11px;color:var(--rc-text-5)">No ranges configured yet</div>');
+    }
+
+    function bindScanPlan() {
+        RC.on(RC.el('rc-subnets'), 'click', '[data-range-id]', function (e, row) {
+            var networkId = row.getAttribute('data-network-id');
+            var rangeId = row.getAttribute('data-range-id');
+            RC.sendJSON('POST', '/api/networks/' + encodeURIComponent(networkId) +
+                '/ranges/' + encodeURIComponent(rangeId) + '/toggle')
+                .then(function () { return window.RCSegments.load(); })
+                .then(function () { renderSubnetsFromState(window.RCDevices.state()); })
+                .catch(function (err) { console.error('Failed to toggle range:', err); });
+        });
     }
 
     /* ── Dock ───────────────────────────────────────────────────────── */
 
     function visibleDevices(state) {
-        if (window.RCMap.showOffline()) return state.devices;
-        return state.devices.filter(function (d) {
+        var devices = window.RCSegments.filterDevices(state.devices);
+        if (window.RCMap.showOffline()) return devices;
+        return devices.filter(function (d) {
             return (d.status || '').toLowerCase() !== 'offline';
         });
     }

--- a/backend/assets/static/js/network-list.js
+++ b/backend/assets/static/js/network-list.js
@@ -26,6 +26,15 @@
         return !!(current && current.id === network.id);
     }
 
+    function rangesSummary(network) {
+        var ranges = (network.ranges || []).filter(function (r) { return r.active; });
+        if (!ranges.length) return network.cidr || '—';
+        if (ranges.length <= 2) {
+            return ranges.map(function (r) { return r.cidr; }).join(', ');
+        }
+        return ranges[0].cidr + ' +' + (ranges.length - 1) + ' more';
+    }
+
     function renderPage() {
         var container = RC.el('rc-networks-page');
         if (!container) return;
@@ -38,7 +47,7 @@
         var rows = networks.map(function (n) {
             var scanning = isScanning(n);
             return '<tr data-network-id="' + RC.esc(n.id) + '">' +
-                '<td class="rc-code">' + RC.esc(n.cidr || '—') + '</td>' +
+                '<td class="rc-code">' + RC.esc(rangesSummary(n)) + '</td>' +
                 '<td style="color:var(--rc-text)">' + RC.esc(n.name || 'unnamed') + '</td>' +
                 '<td>' + RC.esc(n.description || '—') + '</td>' +
                 '<td style="text-align:right">' + RC.esc(String(n.device_count || 0)) + '</td>' +
@@ -64,12 +73,23 @@
 
     /* ── Dialog ─────────────────────────────────────────────────────── */
 
+    function rangeRow(range) {
+        range = range || {};
+        return '<div class="rc-range-row" style="display:flex;gap:6px;margin-bottom:6px">' +
+            '<input class="rc-range-cidr" value="' + RC.esc(range.cidr || '') + '" placeholder="192.168.1.0/24" style="flex:1">' +
+            '<input class="rc-range-label" value="' + RC.esc(range.label || '') + '" placeholder="label (optional)" style="flex:1">' +
+            '<button class="rc-btn rc-btn--danger" data-action="remove-range" type="button" style="padding:3px 8px">⌫</button>' +
+        '</div>';
+    }
+
     function networkForm(network) {
         network = network || {};
+        var ranges = (network.ranges && network.ranges.length) ? network.ranges : [{}];
         return '<div class="rc-form">' +
             '<div class="rc-field">' +
-                '<label for="rc-net-cidr">CIDR</label>' +
-                '<input id="rc-net-cidr" value="' + RC.esc(network.cidr || '') + '" placeholder="192.168.1.0/24">' +
+                '<label>Ranges</label>' +
+                '<div id="rc-net-ranges">' + ranges.map(rangeRow).join('') + '</div>' +
+                '<button class="rc-btn" id="rc-net-add-range" type="button" style="padding:3px 8px">+ ADD RANGE</button>' +
             '</div>' +
             '<div class="rc-field">' +
                 '<label for="rc-net-name">Name</label>' +
@@ -83,6 +103,34 @@
         '</div>';
     }
 
+    function bindRangeRows() {
+        var list = RC.el('rc-net-ranges');
+        var addBtn = RC.el('rc-net-add-range');
+        if (!list || !addBtn) return;
+
+        addBtn.addEventListener('click', function () {
+            list.insertAdjacentHTML('beforeend', rangeRow());
+        });
+
+        RC.on(list, 'click', '[data-action="remove-range"]', function (e, btn) {
+            var row = btn.closest('.rc-range-row');
+            if (row && list.children.length > 1) row.remove();
+        });
+    }
+
+    function collectRanges() {
+        var rows = document.querySelectorAll('#rc-net-ranges .rc-range-row');
+        var cidrs = [], labels = [];
+        rows.forEach(function (row) {
+            var cidr = (row.querySelector('.rc-range-cidr') || {}).value || '';
+            cidr = cidr.trim();
+            if (!cidr) return;
+            cidrs.push(cidr);
+            labels.push(((row.querySelector('.rc-range-label') || {}).value || '').trim());
+        });
+        return { cidrs: cidrs, labels: labels };
+    }
+
     function openNetworkDialog(networkId) {
         var network = networks.filter(function (n) { return n.id === networkId; })[0];
 
@@ -91,20 +139,21 @@
             body: networkForm(network),
             confirm: 'SAVE',
             onConfirm: function () {
-                var fields = {
-                    cidr: (RC.el('rc-net-cidr') || {}).value || '',
-                    name: (RC.el('rc-net-name') || {}).value || '',
-                    description: (RC.el('rc-net-desc') || {}).value || ''
-                };
+                var ranges = collectRanges();
+                var name = (RC.el('rc-net-name') || {}).value || '';
+                var description = (RC.el('rc-net-desc') || {}).value || '';
 
-                if (!fields.cidr.trim()) {
-                    RC.text('rc-net-error', 'A CIDR is required.');
+                if (!ranges.cidrs.length) {
+                    RC.text('rc-net-error', 'At least one CIDR range is required.');
                     return;
                 }
 
                 var url = network ? '/api/networks/' + encodeURIComponent(network.id) : '/api/networks';
                 var body = new URLSearchParams();
-                Object.keys(fields).forEach(function (k) { body.append(k, fields[k]); });
+                body.append('name', name);
+                body.append('description', description);
+                ranges.cidrs.forEach(function (c) { body.append('cidr', c); });
+                ranges.labels.forEach(function (l) { body.append('cidr_label', l); });
 
                 fetch(url, {
                     method: network ? 'PUT' : 'POST',
@@ -115,7 +164,7 @@
                     .then(function (r) { return r.json(); })
                     .then(function (res) {
                         if (!res.success) {
-                            RC.text('rc-net-error', res.message || 'Could not save this network.');
+                            RC.text('rc-net-error', res.message || res.error || 'Could not save this network.');
                             return;
                         }
                         closeDialog();
@@ -127,6 +176,8 @@
                     });
             }
         });
+
+        bindRangeRows();
     }
 
     function deleteNetwork(networkId) {

--- a/backend/assets/static/js/rc.js
+++ b/backend/assets/static/js/rc.js
@@ -164,6 +164,48 @@ window.RC = (function () {
         return (parseInt(hex.slice(0, 2), 16) & 0x02) !== 0;
     }
 
+    // ipToInt/ipInCidr/cidrSize are IPv4-only, matching network_ranges (IPv6
+    // networks stay single-prefix and don't use the ranges table).
+    function ipToInt(ip) {
+        var parts = String(ip || '').split('.');
+        if (parts.length !== 4) return null;
+        var n = 0;
+        for (var i = 0; i < 4; i++) {
+            var octet = Number(parts[i]);
+            if (isNaN(octet) || octet < 0 || octet > 255) return null;
+            n = (n << 8) | octet;
+        }
+        return n >>> 0;
+    }
+
+    function ipInCidr(ip, cidr) {
+        var parts = String(cidr || '').split('/');
+        if (parts.length !== 2) return false;
+
+        var base = ipToInt(parts[0]);
+        var prefix = Number(parts[1]);
+        var target = ipToInt(ip);
+        if (base === null || target === null || isNaN(prefix) || prefix < 0 || prefix > 32) return false;
+
+        if (prefix === 0) return true;
+        var mask = (0xFFFFFFFF << (32 - prefix)) >>> 0;
+        return (base & mask) === (target & mask);
+    }
+
+    // Usable host count (excludes network/broadcast addresses for /0-/30, as
+    // real allocatable capacity is what the Scan Plan panel wants to show).
+    function cidrSize(cidr) {
+        var parts = String(cidr || '').split('/');
+        if (parts.length !== 2) return 0;
+        var prefix = Number(parts[1]);
+        if (isNaN(prefix) || prefix < 0 || prefix > 32) return 0;
+
+        var hostBits = 32 - prefix;
+        if (hostBits === 0) return 1;
+        if (hostBits === 1) return 2;
+        return Math.pow(2, hostBits) - 2;
+    }
+
     // Small localStorage wrapper — private-mode browsers throw on write.
     var store = {
         get: function (key, fallback) {
@@ -216,6 +258,8 @@ window.RC = (function () {
         severityNames: severityNames,
         isInfra: isInfra,
         isUnidentified: isUnidentified,
+        ipInCidr: ipInCidr,
+        cidrSize: cidrSize,
         timeAgo: timeAgo,
         clockTime: clockTime,
         dateTime: dateTime,

--- a/backend/assets/static/js/segments.js
+++ b/backend/assets/static/js/segments.js
@@ -1,0 +1,106 @@
+/* Segments: the per-range status tiles at the top of the SCAN PLAN panel.
+ *
+ * One tile per range across every network. Clicking a tile sets an in-memory
+ * scope that filters the device dock/hosts list by IP-in-CIDR membership —
+ * this is separate from a range's persisted active/inactive scan state,
+ * which the SCAN PLAN list below toggles instead.
+ */
+(function () {
+    'use strict';
+
+    var networks = [];
+    var scopedRangeId = null;
+    var scopeListeners = [];
+
+    function onScopeChange(fn) {
+        scopeListeners.push(fn);
+    }
+
+    function notifyScopeChange() {
+        scopeListeners.forEach(function (fn) {
+            try { fn(scopedCidr()); } catch (e) { console.error('segment scope listener failed', e); }
+        });
+    }
+
+    function load() {
+        return RC.getJSON('/api/networks')
+            .then(function (data) {
+                networks = data.networks || [];
+                render();
+                return networks;
+            })
+            .catch(function (err) {
+                console.error('Failed to load segments:', err);
+                return networks;
+            });
+    }
+
+    function allRanges() {
+        var out = [];
+        networks.forEach(function (n) {
+            (n.ranges || []).forEach(function (r) {
+                out.push({ networkId: n.id, range: r });
+            });
+        });
+        return out;
+    }
+
+    function scopedCidr() {
+        if (!scopedRangeId) return null;
+        var match = allRanges().filter(function (entry) { return entry.range.id === scopedRangeId; })[0];
+        return match ? match.range.cidr : null;
+    }
+
+    // Used by devices.js-driven views to scope the visible device set.
+    function filterDevices(devices) {
+        var cidr = scopedCidr();
+        if (!cidr) return devices;
+        return devices.filter(function (d) { return RC.ipInCidr(d.ipv4, cidr); });
+    }
+
+    function render() {
+        var container = RC.el('rc-segments');
+        if (!container) return;
+
+        var entries = allRanges();
+        if (!entries.length) {
+            RC.render(container, '');
+            return;
+        }
+
+        var devices = (window.RCDevices ? window.RCDevices.state().devices : []) || [];
+
+        RC.render(container, entries.map(function (entry) {
+            var r = entry.range;
+            var count = devices.filter(function (d) { return RC.ipInCidr(d.ipv4, r.cidr); }).length;
+            var classes = ['rc-segment'];
+            if (r.id === scopedRangeId) classes.push('is-active');
+            if (!r.active) classes.push('is-inactive');
+
+            return '<div class="' + classes.join(' ') + '" data-range-id="' + RC.esc(r.id) + '" title="' + RC.esc(r.cidr) + '">' +
+                '<span class="rc-segment__cidr">' + RC.esc(r.label || r.cidr) + '</span>' +
+                '<span class="rc-segment__count">' + count + ' known</span>' +
+                '</div>';
+        }).join(''));
+    }
+
+    function bind() {
+        RC.on(RC.el('rc-segments'), 'click', '[data-range-id]', function (e, tile) {
+            var id = tile.getAttribute('data-range-id');
+            scopedRangeId = (scopedRangeId === id) ? null : id;
+            render();
+            notifyScopeChange();
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', bind);
+
+    window.RCSegments = {
+        load: load,
+        render: render,
+        filterDevices: filterDevices,
+        scopedCidr: scopedCidr,
+        onScopeChange: onScopeChange,
+        networks: function () { return networks; }
+    };
+})();

--- a/backend/assets/templates/index.html
+++ b/backend/assets/templates/index.html
@@ -212,7 +212,8 @@
             </div>
 
             <div class="rc-overlay rc-overlay--tr rc-panel">
-                <div class="rc-panel__head"><span>SUBNET LOAD</span><span style="color:var(--rc-text-5)">ON / KNOWN</span></div>
+                <div class="rc-panel__head"><span>SCAN PLAN</span><span style="color:var(--rc-text-5)">ON / KNOWN</span></div>
+                <div class="rc-segments" id="rc-segments"></div>
                 <div class="rc-subnets" id="rc-subnets"></div>
             </div>
 
@@ -322,6 +323,7 @@
 <script src="/static/js/alerts.js"></script>
 <script src="/static/js/network-list.js"></script>
 <script src="/static/js/network-suggestions.js"></script>
+<script src="/static/js/segments.js"></script>
 <script src="/static/js/scan-control.js"></script>
 <script src="/static/js/settings.js"></script>
 <script src="/static/js/network-viz.js"></script>

--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -28,6 +28,8 @@ type NetworkRepository interface {
 	CreateOrUpdate(ctx context.Context, network *models.Network) (*models.Network, error)
 	Delete(ctx context.Context, id string) error
 	GetDeviceCount(ctx context.Context, networkID string) (int, error)
+	SetRangeActive(ctx context.Context, rangeID string, active bool) error
+	UpdateRangeLastScanned(ctx context.Context, rangeID string, scannedAt time.Time) error
 }
 
 // DeviceStatusChange records one device whose status the status sweeper moved,
@@ -150,4 +152,3 @@ func (f *RepositoryFactory) NewAlertRepository() AlertRepository {
 func GenerateID() string {
 	return uuid.New().String()
 }
-

--- a/backend/db/sqlite.go
+++ b/backend/db/sqlite.go
@@ -425,6 +425,40 @@ func InitializeSchema(db *sql.DB) error {
 		return fmt.Errorf("failed to create index on alerts.rule_id: %w", err)
 	}
 
+	// Create network_ranges table: a network can own multiple CIDR ranges so
+	// scans target only the real subnets in use instead of a covering supernet.
+	_, err = db.Exec(`
+	CREATE TABLE IF NOT EXISTS network_ranges (
+		id TEXT PRIMARY KEY,
+		network_id TEXT NOT NULL REFERENCES networks(id) ON DELETE CASCADE,
+		cidr TEXT NOT NULL,
+		label TEXT,
+		active INTEGER NOT NULL DEFAULT 1,
+		last_scanned_at TIMESTAMP,
+		created_at TIMESTAMP NOT NULL,
+		updated_at TIMESTAMP NOT NULL
+	)`)
+	if err != nil {
+		return fmt.Errorf("failed to create network_ranges table: %w", err)
+	}
+
+	_, err = db.Exec(`CREATE INDEX IF NOT EXISTS idx_network_ranges_network_id ON network_ranges(network_id)`)
+	if err != nil {
+		return fmt.Errorf("failed to create index on network_ranges.network_id: %w", err)
+	}
+
+	// Backfill: every pre-existing single-CIDR network gets one range row.
+	_, err = db.Exec(`
+	INSERT INTO network_ranges (id, network_id, cidr, label, active, last_scanned_at, created_at, updated_at)
+	SELECT lower(hex(randomblob(16))), id, cidr, NULL, 1, last_scanned_at,
+		COALESCE(created_at, CURRENT_TIMESTAMP), COALESCE(updated_at, CURRENT_TIMESTAMP)
+	FROM networks
+	WHERE cidr IS NOT NULL AND cidr != ''
+	AND NOT EXISTS (SELECT 1 FROM network_ranges WHERE network_ranges.network_id = networks.id)`)
+	if err != nil {
+		return fmt.Errorf("failed to backfill network_ranges: %w", err)
+	}
+
 	log.Println("Database schema initialized successfully")
 	return nil
 }

--- a/backend/db/sqlite_repositories.go
+++ b/backend/db/sqlite_repositories.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"reconya/models"
+	"strings"
 	"time"
 )
 
@@ -35,7 +36,7 @@ func (r *SQLiteNetworkRepository) FindByID(ctx context.Context, id string) (*mod
 	var name, description, status sql.NullString
 	var lastScannedAt, createdAt, updatedAt sql.NullTime
 	var deviceCount sql.NullInt64
-	
+
 	err := row.Scan(&network.ID, &name, &network.CIDR, &description, &status, &lastScannedAt, &deviceCount, &createdAt, &updatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -66,11 +67,26 @@ func (r *SQLiteNetworkRepository) FindByID(ctx context.Context, id string) (*mod
 		network.UpdatedAt = updatedAt.Time
 	}
 
+	ranges, err := r.loadRanges(ctx, network.ID)
+	if err != nil {
+		return nil, err
+	}
+	network.Ranges = ranges
+
 	return &network, nil
 }
 
-// FindByCIDR finds a network by CIDR
+// FindByCIDR finds a network owning a range (or its legacy single CIDR column) matching cidr
 func (r *SQLiteNetworkRepository) FindByCIDR(ctx context.Context, cidr string) (*models.Network, error) {
+	var networkID string
+	err := r.db.QueryRowContext(ctx, `SELECT network_id FROM network_ranges WHERE cidr = ? LIMIT 1`, cidr).Scan(&networkID)
+	if err == nil {
+		return r.FindByID(ctx, networkID)
+	}
+	if err != sql.ErrNoRows {
+		return nil, fmt.Errorf("error looking up network range by cidr: %w", err)
+	}
+
 	query := `SELECT id, name, cidr, description, status, last_scanned_at, device_count, created_at, updated_at FROM networks WHERE cidr = ?`
 	row := r.db.QueryRowContext(ctx, query, cidr)
 
@@ -78,8 +94,8 @@ func (r *SQLiteNetworkRepository) FindByCIDR(ctx context.Context, cidr string) (
 	var name, description, status sql.NullString
 	var lastScannedAt, createdAt, updatedAt sql.NullTime
 	var deviceCount sql.NullInt64
-	
-	err := row.Scan(&network.ID, &name, &network.CIDR, &description, &status, &lastScannedAt, &deviceCount, &createdAt, &updatedAt)
+
+	err = row.Scan(&network.ID, &name, &network.CIDR, &description, &status, &lastScannedAt, &deviceCount, &createdAt, &updatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ErrNotFound
@@ -108,6 +124,12 @@ func (r *SQLiteNetworkRepository) FindByCIDR(ctx context.Context, cidr string) (
 	if updatedAt.Valid {
 		network.UpdatedAt = updatedAt.Time
 	}
+
+	ranges, err := r.loadRanges(ctx, network.ID)
+	if err != nil {
+		return nil, err
+	}
+	network.Ranges = ranges
 
 	return &network, nil
 }
@@ -135,7 +157,7 @@ func (r *SQLiteNetworkRepository) FindAll(ctx context.Context) ([]*models.Networ
 		var network models.Network
 		var lastScannedAt sql.NullTime
 		var createdAtStr, updatedAtStr string
-		
+
 		err := rows.Scan(&network.ID, &network.Name, &network.CIDR, &network.Description, &network.Status, &lastScannedAt, &network.DeviceCount, &createdAtStr, &updatedAtStr)
 		if err != nil {
 			return nil, fmt.Errorf("error scanning network: %w", err)
@@ -171,10 +193,86 @@ func (r *SQLiteNetworkRepository) FindAll(ctx context.Context) ([]*models.Networ
 		networks = append(networks, &network)
 	}
 
+	if err := r.attachRanges(ctx, networks); err != nil {
+		return nil, err
+	}
+
 	return networks, nil
 }
 
-// CreateOrUpdate creates or updates a network
+// loadRanges loads the ranges owned by a single network
+func (r *SQLiteNetworkRepository) loadRanges(ctx context.Context, networkID string) ([]models.NetworkRange, error) {
+	rows, err := r.db.QueryContext(ctx, `
+		SELECT id, network_id, cidr, COALESCE(label, ''), active, last_scanned_at, created_at, updated_at
+		FROM network_ranges WHERE network_id = ? ORDER BY created_at ASC`, networkID)
+	if err != nil {
+		return nil, fmt.Errorf("error querying network_ranges: %w", err)
+	}
+	defer rows.Close()
+
+	var ranges []models.NetworkRange
+	for rows.Next() {
+		var nr models.NetworkRange
+		var active int
+		var lastScannedAt sql.NullTime
+		if err := rows.Scan(&nr.ID, &nr.NetworkID, &nr.CIDR, &nr.Label, &active, &lastScannedAt, &nr.CreatedAt, &nr.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("error scanning network_range: %w", err)
+		}
+		nr.Active = active != 0
+		if lastScannedAt.Valid {
+			nr.LastScannedAt = &lastScannedAt.Time
+		}
+		ranges = append(ranges, nr)
+	}
+	return ranges, nil
+}
+
+// attachRanges batch-loads ranges for a set of networks to avoid N+1 queries
+func (r *SQLiteNetworkRepository) attachRanges(ctx context.Context, networks []*models.Network) error {
+	if len(networks) == 0 {
+		return nil
+	}
+
+	byID := make(map[string]*models.Network, len(networks))
+	placeholders := make([]string, 0, len(networks))
+	args := make([]interface{}, 0, len(networks))
+	for _, n := range networks {
+		byID[n.ID] = n
+		placeholders = append(placeholders, "?")
+		args = append(args, n.ID)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT id, network_id, cidr, COALESCE(label, ''), active, last_scanned_at, created_at, updated_at
+		FROM network_ranges WHERE network_id IN (%s) ORDER BY created_at ASC`, strings.Join(placeholders, ","))
+	rows, err := r.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return fmt.Errorf("error querying network_ranges: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var nr models.NetworkRange
+		var active int
+		var lastScannedAt sql.NullTime
+		if err := rows.Scan(&nr.ID, &nr.NetworkID, &nr.CIDR, &nr.Label, &active, &lastScannedAt, &nr.CreatedAt, &nr.UpdatedAt); err != nil {
+			return fmt.Errorf("error scanning network_range: %w", err)
+		}
+		nr.Active = active != 0
+		if lastScannedAt.Valid {
+			nr.LastScannedAt = &lastScannedAt.Time
+		}
+		if n, ok := byID[nr.NetworkID]; ok {
+			n.Ranges = append(n.Ranges, nr)
+		}
+	}
+	return nil
+}
+
+// CreateOrUpdate creates or updates a network, reconciling its ranges.
+// Ranges present in network.Ranges are upserted by CIDR; existing ranges
+// whose CIDR isn't in the incoming set are marked inactive rather than
+// deleted, so their last_scanned_at history survives an edit.
 func (r *SQLiteNetworkRepository) CreateOrUpdate(ctx context.Context, network *models.Network) (*models.Network, error) {
 	if network.ID == "" {
 		network.ID = GenerateID()
@@ -184,25 +282,141 @@ func (r *SQLiteNetworkRepository) CreateOrUpdate(ctx context.Context, network *m
 	if err != nil && err != ErrNotFound {
 		return nil, err
 	}
+	isNew := err == ErrNotFound
 
-	if err == ErrNotFound {
-		query := `INSERT INTO networks (id, name, cidr, description, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`
-		_, err := r.db.ExecContext(ctx, query, network.ID, network.Name, network.CIDR, network.Description, network.Status, network.CreatedAt, network.UpdatedAt)
+	tx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error starting transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	if isNew {
+		_, err = tx.ExecContext(ctx,
+			`INSERT INTO networks (id, name, cidr, description, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			network.ID, network.Name, network.CIDR, network.Description, network.Status, network.CreatedAt, network.UpdatedAt)
 		if err != nil {
 			return nil, fmt.Errorf("error inserting network: %w", err)
 		}
 	} else {
-		query := `UPDATE networks SET name = ?, cidr = ?, description = ?, status = ?, updated_at = ? WHERE id = ?`
-		_, err := r.db.ExecContext(ctx, query, network.Name, network.CIDR, network.Description, network.Status, network.UpdatedAt, network.ID)
+		_, err = tx.ExecContext(ctx,
+			`UPDATE networks SET name = ?, cidr = ?, description = ?, status = ?, updated_at = ? WHERE id = ?`,
+			network.Name, network.CIDR, network.Description, network.Status, network.UpdatedAt, network.ID)
 		if err != nil {
 			return nil, fmt.Errorf("error updating network: %w", err)
 		}
 	}
 
+	if err := reconcileNetworkRanges(ctx, tx, network); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("error committing network update: %w", err)
+	}
+
+	ranges, err := r.loadRanges(ctx, network.ID)
+	if err != nil {
+		return nil, err
+	}
+	network.Ranges = ranges
+
 	return network, nil
 }
 
-// Delete deletes a network by ID
+func reconcileNetworkRanges(ctx context.Context, tx *sql.Tx, network *models.Network) error {
+	existingRows, err := tx.QueryContext(ctx, `SELECT id, cidr FROM network_ranges WHERE network_id = ?`, network.ID)
+	if err != nil {
+		return fmt.Errorf("error loading existing network_ranges: %w", err)
+	}
+	existingByCIDR := make(map[string]string) // cidr -> id
+	for existingRows.Next() {
+		var id, cidr string
+		if err := existingRows.Scan(&id, &cidr); err != nil {
+			existingRows.Close()
+			return fmt.Errorf("error scanning existing network_range: %w", err)
+		}
+		existingByCIDR[cidr] = id
+	}
+	existingRows.Close()
+
+	now := time.Now()
+	seen := make(map[string]bool)
+
+	for i := range network.Ranges {
+		nr := &network.Ranges[i]
+		seen[nr.CIDR] = true
+
+		if id, ok := existingByCIDR[nr.CIDR]; ok {
+			_, err = tx.ExecContext(ctx,
+				`UPDATE network_ranges SET label = ?, active = 1, updated_at = ? WHERE id = ?`,
+				nr.Label, now, id)
+			if err != nil {
+				return fmt.Errorf("error updating network_range: %w", err)
+			}
+			nr.ID = id
+		} else {
+			nr.ID = GenerateID()
+			_, err = tx.ExecContext(ctx,
+				`INSERT INTO network_ranges (id, network_id, cidr, label, active, created_at, updated_at) VALUES (?, ?, ?, ?, 1, ?, ?)`,
+				nr.ID, network.ID, nr.CIDR, nr.Label, now, now)
+			if err != nil {
+				return fmt.Errorf("error inserting network_range: %w", err)
+			}
+		}
+	}
+
+	for cidr, id := range existingByCIDR {
+		if !seen[cidr] {
+			_, err = tx.ExecContext(ctx,
+				`UPDATE network_ranges SET active = 0, updated_at = ? WHERE id = ?`, now, id)
+			if err != nil {
+				return fmt.Errorf("error deactivating network_range: %w", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// SetRangeActive toggles whether a range is included in scans
+func (r *SQLiteNetworkRepository) SetRangeActive(ctx context.Context, rangeID string, active bool) error {
+	activeVal := 0
+	if active {
+		activeVal = 1
+	}
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE network_ranges SET active = ?, updated_at = ? WHERE id = ?`, activeVal, time.Now(), rangeID)
+	if err != nil {
+		return fmt.Errorf("error setting network_range active state: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("error checking network_range update result: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateRangeLastScanned records when a range was last swept
+func (r *SQLiteNetworkRepository) UpdateRangeLastScanned(ctx context.Context, rangeID string, scannedAt time.Time) error {
+	res, err := r.db.ExecContext(ctx,
+		`UPDATE network_ranges SET last_scanned_at = ?, updated_at = ? WHERE id = ?`, scannedAt, time.Now(), rangeID)
+	if err != nil {
+		return fmt.Errorf("error updating network_range last_scanned_at: %w", err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("error checking network_range update result: %w", err)
+	}
+	if rows == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// Delete deletes a network by ID. network_ranges are removed via ON DELETE CASCADE.
 func (r *SQLiteNetworkRepository) Delete(ctx context.Context, id string) error {
 	query := `DELETE FROM networks WHERE id = ?`
 	_, err := r.db.ExecContext(ctx, query, id)
@@ -216,13 +430,13 @@ func (r *SQLiteNetworkRepository) Delete(ctx context.Context, id string) error {
 func (r *SQLiteNetworkRepository) GetDeviceCount(ctx context.Context, networkID string) (int, error) {
 	query := `SELECT COUNT(*) FROM devices WHERE network_id = ?`
 	row := r.db.QueryRowContext(ctx, query, networkID)
-	
+
 	var count int
 	err := row.Scan(&count)
 	if err != nil {
 		return 0, fmt.Errorf("error counting devices for network: %w", err)
 	}
-	
+
 	return count, nil
 }
 
@@ -272,7 +486,7 @@ func (r *SQLiteDeviceRepository) FindByID(ctx context.Context, id string) (*mode
 	var lastSeenOnlineAt, portScanStartedAt, portScanEndedAt, webScanEndedAt sql.NullTime
 
 	err = row.Scan(
-		&device.ID, &device.Name, &comment, &device.IPv4, 
+		&device.ID, &device.Name, &comment, &device.IPv4,
 		&ipv6LinkLocal, &ipv6UniqueLocal, &ipv6Global, &ipv6Addresses,
 		&mac, &vendor, &deviceType,
 		&osName, &osVersion, &osFamily, &osConfidence,
@@ -290,7 +504,7 @@ func (r *SQLiteDeviceRepository) FindByID(ctx context.Context, id string) (*mode
 	if networkID.Valid {
 		device.NetworkID = networkID.String
 	}
-	
+
 	if mac.Valid {
 		device.MAC = &mac.String
 	}
@@ -300,7 +514,7 @@ func (r *SQLiteDeviceRepository) FindByID(ctx context.Context, id string) (*mode
 	if comment.Valid {
 		device.Comment = &comment.String
 	}
-	
+
 	// IPv6 fields
 	if ipv6LinkLocal.Valid {
 		device.IPv6LinkLocal = &ipv6LinkLocal.String
@@ -336,7 +550,7 @@ func (r *SQLiteDeviceRepository) FindByID(ctx context.Context, id string) (*mode
 	if webScanEndedAt.Valid {
 		device.WebScanEndedAt = &webScanEndedAt.Time
 	}
-	
+
 	// Set OS information
 	if osName.Valid || osVersion.Valid || osFamily.Valid || osConfidence.Valid {
 		device.OS = &models.DeviceOS{}
@@ -371,12 +585,11 @@ func (r *SQLiteDeviceRepository) FindByID(ctx context.Context, id string) (*mode
 		}
 		device.Ports = append(device.Ports, port)
 	}
-	
+
 	// Check for errors from iterating over rows
 	if err := portRows.Err(); err != nil {
 		return nil, fmt.Errorf("error iterating over port rows: %w", err)
 	}
-	
 
 	// Load web services
 	webServicesQuery := `
@@ -396,7 +609,7 @@ func (r *SQLiteDeviceRepository) FindByID(ctx context.Context, id string) (*mode
 		if err := webServiceRows.Scan(&ws.URL, &title, &server, &ws.StatusCode, &contentType, &size, &screenshot, &ws.Port, &ws.Protocol, &ws.ScannedAt); err != nil {
 			return nil, fmt.Errorf("error scanning web service: %w", err)
 		}
-		
+
 		if title.Valid {
 			ws.Title = title.String
 		}
@@ -412,7 +625,7 @@ func (r *SQLiteDeviceRepository) FindByID(ctx context.Context, id string) (*mode
 		if screenshot.Valid {
 			ws.Screenshot = screenshot.String
 		}
-		
+
 		device.WebServices = append(device.WebServices, ws)
 	}
 
@@ -492,26 +705,26 @@ func (r *SQLiteDeviceRepository) CreateOrUpdate(ctx context.Context, device *mod
 	if deviceExists {
 		// Update existing device with the same IP address
 		device.ID = existingID
-		
+
 		// Get the existing created_at timestamp and preserve device type/OS if not provided
 		var createdAt time.Time
 		var existingDeviceType sql.NullString
 		var existingOsName, existingOsVersion, existingOsFamily sql.NullString
 		var existingOsConfidence sql.NullInt64
-		
-		err = tx.QueryRowContext(ctx, 
-			"SELECT created_at, device_type, os_name, os_version, os_family, os_confidence FROM devices WHERE id = ?", 
+
+		err = tx.QueryRowContext(ctx,
+			"SELECT created_at, device_type, os_name, os_version, os_family, os_confidence FROM devices WHERE id = ?",
 			device.ID).Scan(&createdAt, &existingDeviceType, &existingOsName, &existingOsVersion, &existingOsFamily, &existingOsConfidence)
 		if err != nil {
 			return nil, fmt.Errorf("error getting existing device data: %w", err)
 		}
 		device.CreatedAt = createdAt
-		
+
 		// Preserve existing device type if not provided in update
 		if device.DeviceType == "" && existingDeviceType.Valid {
 			device.DeviceType = models.DeviceType(existingDeviceType.String)
 		}
-		
+
 		// Preserve existing OS data if not provided in update
 		if device.OS == nil && (existingOsName.Valid || existingOsVersion.Valid || existingOsFamily.Valid || existingOsConfidence.Valid) {
 			device.OS = &models.DeviceOS{}
@@ -564,7 +777,7 @@ func (r *SQLiteDeviceRepository) CreateOrUpdate(ctx context.Context, device *mod
 		}
 
 		_, err = tx.ExecContext(ctx, query,
-			device.Name, nullableString(device.Comment), nullableString(device.MAC), nullableString(device.Vendor), 
+			device.Name, nullableString(device.Comment), nullableString(device.MAC), nullableString(device.Vendor),
 			string(device.DeviceType), osName, osVersion, osFamily, osConfidence,
 			device.Status, networkIDPtr, nullableString(device.Hostname),
 			device.UpdatedAt, nullableTime(device.LastSeenOnlineAt),
@@ -1123,7 +1336,7 @@ func (r *SQLiteSettingsRepository) FindByUserID(userID string) (*models.Settings
 
 	var settings models.Settings
 	var createdAt, updatedAt sql.NullTime
-	
+
 	err := row.Scan(&settings.ID, &settings.UserID, &settings.ScreenshotsEnabled, &createdAt, &updatedAt)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -1146,24 +1359,24 @@ func (r *SQLiteSettingsRepository) FindByUserID(userID string) (*models.Settings
 func (r *SQLiteSettingsRepository) Create(settings *models.Settings) error {
 	query := `INSERT INTO settings (id, user_id, screenshots_enabled, created_at, updated_at) 
 			  VALUES (?, ?, ?, ?, ?)`
-	
-	_, err := r.db.Exec(query, settings.ID, settings.UserID, settings.ScreenshotsEnabled, 
+
+	_, err := r.db.Exec(query, settings.ID, settings.UserID, settings.ScreenshotsEnabled,
 		settings.CreatedAt, settings.UpdatedAt)
 	if err != nil {
 		return fmt.Errorf("error creating settings: %w", err)
 	}
-	
+
 	return nil
 }
 
 // Update updates existing settings
 func (r *SQLiteSettingsRepository) Update(settings *models.Settings) error {
 	query := `UPDATE settings SET screenshots_enabled = ?, updated_at = ? WHERE id = ?`
-	
+
 	_, err := r.db.Exec(query, settings.ScreenshotsEnabled, settings.UpdatedAt, settings.ID)
 	if err != nil {
 		return fmt.Errorf("error updating settings: %w", err)
 	}
-	
+
 	return nil
 }

--- a/backend/internal/network/network_service.go
+++ b/backend/internal/network/network_service.go
@@ -23,17 +23,25 @@ func NewNetworkService(networkRepo db.NetworkRepository, cfg *config.Config, dbM
 	}
 }
 
-func (s *NetworkService) Create(name, cidr, description string) (*models.Network, error) {
+// Create creates a network owning one or more CIDR ranges. labels is optional
+// and, if provided, must be the same length as cidrs.
+func (s *NetworkService) Create(name string, cidrs []string, labels []string, description string) (*models.Network, error) {
+	if err := models.ValidateNetworkRanges(cidrs); err != nil {
+		return nil, err
+	}
+
 	now := time.Now()
+	ranges := buildRanges(cidrs, labels, now)
 	network := &models.Network{
 		Name:        name,
-		CIDR:        cidr,
+		CIDR:        ranges[0].CIDR,
 		Description: description,
 		Status:      "active",
+		Ranges:      ranges,
 		CreatedAt:   now,
 		UpdatedAt:   now,
 	}
-	log.Printf("NetworkService.Create: Creating network with CIDR=%s, Name=%s", cidr, name)
+	log.Printf("NetworkService.Create: Creating network with %d range(s), Name=%s", len(cidrs), name)
 	result, err := s.dbManager.CreateOrUpdateNetwork(s.Repository, context.Background(), network)
 	if err != nil {
 		log.Printf("NetworkService.Create: Error from dbManager: %v", err)
@@ -43,10 +51,30 @@ func (s *NetworkService) Create(name, cidr, description string) (*models.Network
 	return result, nil
 }
 
+func buildRanges(cidrs []string, labels []string, now time.Time) []models.NetworkRange {
+	ranges := make([]models.NetworkRange, len(cidrs))
+	for i, cidr := range cidrs {
+		label := ""
+		if i < len(labels) {
+			label = labels[i]
+		}
+		ranges[i] = models.NetworkRange{
+			CIDR:      cidr,
+			Label:     label,
+			Active:    true,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+	}
+	return ranges
+}
+
+// FindOrCreate is used by network auto-discovery, which only ever deals with
+// a single detected subnet.
 func (s *NetworkService) FindOrCreate(cidr string) (*models.Network, error) {
 	network, err := s.Repository.FindByCIDR(context.Background(), cidr)
 	if err == db.ErrNotFound {
-		return s.Create("", cidr, "")
+		return s.Create("", []string{cidr}, nil, "")
 	}
 	if err != nil {
 		return nil, err
@@ -76,7 +104,6 @@ func (s *NetworkService) FindByCIDR(cidr string) (*models.Network, error) {
 	return network, nil
 }
 
-
 func (s *NetworkService) FindAll() ([]models.Network, error) {
 	log.Printf("NetworkService.FindAll: Fetching all networks")
 	networks, err := s.Repository.FindAll(context.Background())
@@ -84,7 +111,7 @@ func (s *NetworkService) FindAll() ([]models.Network, error) {
 		log.Printf("NetworkService.FindAll: Error from repository: %v", err)
 		return nil, err
 	}
-	
+
 	log.Printf("NetworkService.FindAll: Found %d networks", len(networks))
 	result := make([]models.Network, len(networks))
 	for i, network := range networks {
@@ -94,7 +121,14 @@ func (s *NetworkService) FindAll() ([]models.Network, error) {
 	return result, nil
 }
 
-func (s *NetworkService) Update(id, name, cidr, description string) (*models.Network, error) {
+// Update replaces a network's name/ranges/description. labels is optional
+// and, if provided, must be the same length as cidrs. Existing ranges whose
+// CIDR matches one in cidrs keep their id and last_scanned_at history.
+func (s *NetworkService) Update(id, name string, cidrs []string, labels []string, description string) (*models.Network, error) {
+	if err := models.ValidateNetworkRanges(cidrs); err != nil {
+		return nil, err
+	}
+
 	network, err := s.FindByID(id)
 	if err != nil {
 		return nil, err
@@ -102,13 +136,26 @@ func (s *NetworkService) Update(id, name, cidr, description string) (*models.Net
 	if network == nil {
 		return nil, db.ErrNotFound
 	}
-	
+
+	now := time.Now()
 	network.Name = name
-	network.CIDR = cidr
+	network.Ranges = buildRanges(cidrs, labels, now)
+	network.CIDR = network.Ranges[0].CIDR
 	network.Description = description
-	network.UpdatedAt = time.Now()
-	
+	network.UpdatedAt = now
+
 	return s.dbManager.CreateOrUpdateNetwork(s.Repository, context.Background(), network)
+}
+
+// SetRangeActive includes or excludes a range from future scans without
+// losing its scan history.
+func (s *NetworkService) SetRangeActive(rangeID string, active bool) error {
+	return s.Repository.SetRangeActive(context.Background(), rangeID, active)
+}
+
+// MarkRangeScanned records when a range was last swept.
+func (s *NetworkService) MarkRangeScanned(rangeID string, scannedAt time.Time) error {
+	return s.Repository.UpdateRangeLastScanned(context.Background(), rangeID, scannedAt)
 }
 
 func (s *NetworkService) Delete(id string) error {
@@ -117,13 +164,13 @@ func (s *NetworkService) Delete(id string) error {
 
 func (s *NetworkService) GetDeviceCount(networkID string) (int, error) {
 	log.Printf("NetworkService.GetDeviceCount: Counting devices for network %s", networkID)
-	
+
 	count, err := s.Repository.GetDeviceCount(context.Background(), networkID)
 	if err != nil {
 		log.Printf("NetworkService.GetDeviceCount: Error counting devices: %v", err)
 		return 0, err
 	}
-	
+
 	log.Printf("NetworkService.GetDeviceCount: Found %d devices for network %s", count, networkID)
 	return count, nil
 }

--- a/backend/internal/network/network_service_test.go
+++ b/backend/internal/network/network_service_test.go
@@ -1,0 +1,127 @@
+package network_test
+
+import (
+	"testing"
+
+	"reconya/db"
+	"reconya/internal/network"
+	"reconya/tests/testutils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestService(t *testing.T) *network.NetworkService {
+	factory, cleanup := testutils.SetupTestRepositoryFactory(t)
+	t.Cleanup(cleanup)
+
+	repo := factory.NewNetworkRepository()
+	cfg := testutils.GetTestConfig()
+	dbManager := db.NewDBManager()
+
+	return network.NewNetworkService(repo, cfg, dbManager)
+}
+
+func TestNetworkService_Create_MultipleRanges(t *testing.T) {
+	svc := newTestService(t)
+
+	n, err := svc.Create("Office", []string{"10.0.1.0/24", "10.0.2.0/24"}, []string{"floor 1", "floor 2"}, "desc")
+	require.NoError(t, err)
+
+	assert.Len(t, n.Ranges, 2)
+	assert.Equal(t, "10.0.1.0/24", n.Ranges[0].CIDR)
+	assert.Equal(t, "floor 1", n.Ranges[0].Label)
+	assert.True(t, n.Ranges[0].Active)
+	assert.Equal(t, "10.0.1.0/24", n.CIDR, "legacy CIDR column mirrors the first range")
+
+	reloaded, err := svc.FindByID(n.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded)
+	assert.Len(t, reloaded.Ranges, 2)
+}
+
+func TestNetworkService_Create_RejectsInvalidCIDR(t *testing.T) {
+	svc := newTestService(t)
+
+	_, err := svc.Create("Office", []string{"not-a-cidr"}, nil, "")
+	assert.Error(t, err)
+
+	_, err = svc.Create("Office", nil, nil, "")
+	assert.Error(t, err)
+}
+
+func TestNetworkService_Update_PreservesRangeIDAcrossEdit(t *testing.T) {
+	svc := newTestService(t)
+
+	created, err := svc.Create("Office", []string{"10.0.1.0/24", "10.0.2.0/24"}, nil, "")
+	require.NoError(t, err)
+
+	originalRangeID := created.Ranges[0].ID
+	require.NotEmpty(t, originalRangeID)
+
+	// Update keeps 10.0.1.0/24, drops 10.0.2.0/24, adds 10.0.3.0/24.
+	updated, err := svc.Update(created.ID, "Office", []string{"10.0.1.0/24", "10.0.3.0/24"}, nil, "")
+	require.NoError(t, err)
+
+	var kept, dropped, added *string
+	for i := range updated.Ranges {
+		r := updated.Ranges[i]
+		switch r.CIDR {
+		case "10.0.1.0/24":
+			kept = &r.ID
+		case "10.0.3.0/24":
+			added = &r.ID
+		}
+	}
+	_ = dropped
+
+	require.NotNil(t, kept)
+	assert.Equal(t, originalRangeID, *kept, "surviving range keeps its id and scan history")
+	require.NotNil(t, added)
+	assert.NotEmpty(t, *added)
+
+	reloaded, err := svc.FindByID(created.ID)
+	require.NoError(t, err)
+
+	active := reloaded.ActiveRanges()
+	activeCIDRs := make([]string, len(active))
+	for i, r := range active {
+		activeCIDRs[i] = r.CIDR
+	}
+	assert.ElementsMatch(t, []string{"10.0.1.0/24", "10.0.3.0/24"}, activeCIDRs,
+		"dropped range is deactivated, not deleted")
+}
+
+func TestNetworkService_SetRangeActive(t *testing.T) {
+	svc := newTestService(t)
+
+	created, err := svc.Create("Office", []string{"10.0.1.0/24"}, nil, "")
+	require.NoError(t, err)
+	rangeID := created.Ranges[0].ID
+
+	require.NoError(t, svc.SetRangeActive(rangeID, false))
+
+	reloaded, err := svc.FindByID(created.ID)
+	require.NoError(t, err)
+	require.Len(t, reloaded.Ranges, 1)
+	assert.False(t, reloaded.Ranges[0].Active)
+	assert.Empty(t, reloaded.ActiveRanges())
+
+	require.NoError(t, svc.SetRangeActive(rangeID, true))
+
+	reloaded, err = svc.FindByID(created.ID)
+	require.NoError(t, err)
+	assert.True(t, reloaded.Ranges[0].Active)
+}
+
+func TestNetworkService_FindOrCreate_SingleRange(t *testing.T) {
+	svc := newTestService(t)
+
+	created, err := svc.FindOrCreate("10.0.1.0/24")
+	require.NoError(t, err)
+	require.Len(t, created.Ranges, 1)
+
+	found, err := svc.FindOrCreate("10.0.1.0/24")
+	require.NoError(t, err)
+	assert.Equal(t, created.ID, found.ID, "second call finds the existing network by range CIDR")
+}

--- a/backend/internal/pingsweep/ping_sweep_service.go
+++ b/backend/internal/pingsweep/ping_sweep_service.go
@@ -11,6 +11,7 @@ import (
 	"reconya/internal/scanner"
 	"reconya/models"
 	"sync"
+	"time"
 )
 
 type PingSweepService struct {
@@ -44,6 +45,7 @@ func NewPingSweepService(
 
 	return service
 }
+
 // Run method is deprecated - use the scan manager to control scanning
 // This method is kept for compatibility but should not be called directly
 func (s *PingSweepService) Run() {
@@ -61,6 +63,56 @@ func (s *PingSweepService) ExecuteSweepScanCommand(network string) ([]models.Dev
 	log.Printf("Network scan succeeded. Found %d devices", len(devices))
 
 	return devices, nil
+}
+
+// ExecuteSweepScanForRanges sweeps each active range of a network in turn,
+// merging the results into one device list keyed by IP. Ranges are scanned
+// sequentially rather than concurrently: the native scanner's ARP cache is a
+// single package-global snapshot that gets reset at the start of every
+// ScanNetwork call, so parallel range scans would race and corrupt each
+// other's ARP resolution.
+func (s *PingSweepService) ExecuteSweepScanForRanges(ranges []models.NetworkRange) ([]models.Device, error) {
+	var perRange [][]models.Device
+
+	for _, r := range ranges {
+		devices, err := s.executeWithFallback(r.CIDR)
+		if err != nil {
+			log.Printf("Range scan failed for %s: %v", r.CIDR, err)
+			continue
+		}
+		perRange = append(perRange, devices)
+
+		if s.NetworkService != nil && r.ID != "" {
+			if err := s.NetworkService.MarkRangeScanned(r.ID, time.Now()); err != nil {
+				log.Printf("Failed to record last_scanned_at for range %s: %v", r.CIDR, err)
+			}
+		}
+	}
+
+	result := mergeDevicesByIP(perRange...)
+
+	log.Printf("Multi-range scan succeeded across %d range(s). Found %d unique devices", len(ranges), len(result))
+
+	return result, nil
+}
+
+// mergeDevicesByIP flattens multiple ranges' scan results into one list,
+// keyed by IP so a host visible from more than one range (overlapping
+// ranges, or a broadcast/gateway address shared across subnets) is only
+// reported once. Later batches win on conflict.
+func mergeDevicesByIP(batches ...[]models.Device) []models.Device {
+	merged := make(map[string]models.Device)
+	for _, batch := range batches {
+		for _, d := range batch {
+			merged[d.IPv4] = d
+		}
+	}
+
+	result := make([]models.Device, 0, len(merged))
+	for _, d := range merged {
+		result = append(result, d)
+	}
+	return result
 }
 
 // executeWithFallback performs network scan using native Go scanner

--- a/backend/internal/pingsweep/ping_sweep_service_test.go
+++ b/backend/internal/pingsweep/ping_sweep_service_test.go
@@ -1,0 +1,51 @@
+package pingsweep
+
+import (
+	"testing"
+
+	"reconya/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeDevicesByIP_DedupesAcrossRanges(t *testing.T) {
+	rangeA := []models.Device{
+		{IPv4: "10.0.1.5", Name: "a"},
+		{IPv4: "10.0.1.6", Name: "b"},
+	}
+	rangeB := []models.Device{
+		{IPv4: "10.0.2.5", Name: "c"},
+	}
+
+	merged := mergeDevicesByIP(rangeA, rangeB)
+
+	assert.Len(t, merged, 3)
+	assertContainsIP(t, merged, "10.0.1.5")
+	assertContainsIP(t, merged, "10.0.1.6")
+	assertContainsIP(t, merged, "10.0.2.5")
+}
+
+func TestMergeDevicesByIP_LaterBatchWinsOnOverlap(t *testing.T) {
+	rangeA := []models.Device{{IPv4: "10.0.1.5", Name: "stale"}}
+	rangeB := []models.Device{{IPv4: "10.0.1.5", Name: "fresh"}}
+
+	merged := mergeDevicesByIP(rangeA, rangeB)
+
+	assert.Len(t, merged, 1)
+	assert.Equal(t, "fresh", merged[0].Name)
+}
+
+func TestMergeDevicesByIP_Empty(t *testing.T) {
+	assert.Empty(t, mergeDevicesByIP())
+	assert.Empty(t, mergeDevicesByIP(nil, []models.Device{}))
+}
+
+func assertContainsIP(t *testing.T, devices []models.Device, ip string) {
+	t.Helper()
+	for _, d := range devices {
+		if d.IPv4 == ip {
+			return
+		}
+	}
+	t.Errorf("expected devices to contain IP %s", ip)
+}

--- a/backend/internal/scan/scan_manager.go
+++ b/backend/internal/scan/scan_manager.go
@@ -4,24 +4,24 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"reconya/internal/ipv6monitor"
+	"reconya/internal/network"
+	"reconya/internal/pingsweep"
+	"reconya/models"
 	"sync"
 	"time"
-	"reconya/models"
-	"reconya/internal/pingsweep"
-	"reconya/internal/network"
-	"reconya/internal/ipv6monitor"
 )
 
 // ScanState represents the current state of the scanning system
 type ScanState struct {
-	IsRunning       bool              `json:"is_running"`
-	IsStopping      bool              `json:"is_stopping"`
-	CurrentNetwork  *models.Network   `json:"current_network"`
-	SelectedNetwork *models.Network   `json:"selected_network"`
-	StartTime       *time.Time        `json:"start_time"`
-	LastScanTime    *time.Time        `json:"last_scan_time"`
-	ScanCount       int               `json:"scan_count"`
-	IPv6Monitoring  bool              `json:"ipv6_monitoring"`
+	IsRunning       bool            `json:"is_running"`
+	IsStopping      bool            `json:"is_stopping"`
+	CurrentNetwork  *models.Network `json:"current_network"`
+	SelectedNetwork *models.Network `json:"selected_network"`
+	StartTime       *time.Time      `json:"start_time"`
+	LastScanTime    *time.Time      `json:"last_scan_time"`
+	ScanCount       int             `json:"scan_count"`
+	IPv6Monitoring  bool            `json:"ipv6_monitoring"`
 }
 
 // AlertEvaluator is the slice of the alert service the scan loop needs. It is
@@ -34,14 +34,14 @@ type AlertEvaluator interface {
 
 // ScanManager manages the network scanning state and operations
 type ScanManager struct {
-	state           ScanState
-	mutex           sync.RWMutex
-	pingSweepService *pingsweep.PingSweepService
-	networkService  *network.NetworkService
+	state              ScanState
+	mutex              sync.RWMutex
+	pingSweepService   *pingsweep.PingSweepService
+	networkService     *network.NetworkService
 	ipv6MonitorService *ipv6monitor.IPv6MonitorService
-	alertService    AlertEvaluator
-	stopChannel     chan bool
-	done            chan bool
+	alertService       AlertEvaluator
+	stopChannel        chan bool
+	done               chan bool
 }
 
 // NewScanManager creates a new scan manager. alertService may be nil, in which
@@ -49,13 +49,13 @@ type ScanManager struct {
 func NewScanManager(pingSweepService *pingsweep.PingSweepService, networkService *network.NetworkService, ipv6MonitorService *ipv6monitor.IPv6MonitorService, alertService AlertEvaluator) *ScanManager {
 	return &ScanManager{
 		state: ScanState{
-			IsRunning: false,
+			IsRunning:      false,
 			IPv6Monitoring: false,
 		},
-		pingSweepService: pingSweepService,
-		networkService:  networkService,
+		pingSweepService:   pingSweepService,
+		networkService:     networkService,
 		ipv6MonitorService: ipv6MonitorService,
-		alertService:    alertService,
+		alertService:       alertService,
 	}
 }
 
@@ -95,7 +95,7 @@ func (sm *ScanManager) getLastScanTime() *time.Time {
 	if err != nil {
 		return nil
 	}
-	
+
 	for _, event := range events {
 		if event.Type == models.PingSweep && event.DurationSeconds != nil {
 			// Return the time of the most recent completed ping sweep
@@ -142,7 +142,7 @@ func (sm *ScanManager) SetSelectedNetwork(networkID string) error {
 func (sm *ScanManager) GetSelectedOrCurrentNetwork() *models.Network {
 	sm.mutex.RLock()
 	defer sm.mutex.RUnlock()
-	
+
 	if sm.state.IsRunning && sm.state.CurrentNetwork != nil {
 		return sm.state.CurrentNetwork
 	}
@@ -171,7 +171,7 @@ func (sm *ScanManager) StartScan(networkID string) error {
 	now := time.Now()
 	sm.state.IsRunning = true
 	sm.state.CurrentNetwork = network
-	sm.state.SelectedNetwork = network  // Also update selected network
+	sm.state.SelectedNetwork = network // Also update selected network
 	sm.state.StartTime = &now
 	sm.state.ScanCount = 0
 
@@ -219,21 +219,21 @@ func (sm *ScanManager) StopScan() error {
 
 	// Set stopping state
 	sm.state.IsStopping = true
-	
+
 	// Signal the scan loop to stop
 	close(sm.stopChannel)
-	
+
 	// Wait for the scan loop to finish
 	go func() {
 		<-sm.done
-		
+
 		// Stop the IPv6 monitoring service
 		if err := sm.ipv6MonitorService.Stop(); err != nil {
 			log.Printf("Error stopping IPv6 monitoring service: %v", err)
 		} else {
 			log.Printf("Stopped IPv6 monitoring service")
 		}
-		
+
 		sm.mutex.Lock()
 		defer sm.mutex.Unlock()
 		sm.state.IsRunning = false
@@ -311,8 +311,8 @@ func (sm *ScanManager) runSingleScan() {
 		log.Printf("Error creating ping sweep started event log: %v", err)
 	}
 
-	// Execute the ping sweep with the current network
-	devices, err := sm.pingSweepService.ExecuteSweepScanCommand(network.CIDR)
+	// Execute the ping sweep across the network's active ranges
+	devices, err := sm.pingSweepService.ExecuteSweepScanForRanges(network.ActiveRanges())
 	if err != nil {
 		log.Printf("Error during ping sweep: %v", err)
 		return
@@ -352,7 +352,7 @@ func (sm *ScanManager) runSingleScan() {
 		// which "first sighting" and "newly opened port" are knowable.
 		if sm.alertService != nil && delta != nil {
 			if delta.IsNew {
-				sm.alertService.RecordNewDevice(context.Background(), updatedDevice, network.CIDR)
+				sm.alertService.RecordNewDevice(context.Background(), updatedDevice, network.GetDisplayName())
 			}
 			if len(delta.NewPorts) > 0 {
 				sm.alertService.RecordNewPorts(context.Background(), updatedDevice, delta.NewPorts)
@@ -391,7 +391,7 @@ func (sm *ScanManager) runSingleScan() {
 	// Create event log for ping sweep completion
 	durationInSeconds := float64(duration.Seconds())
 	err = sm.pingSweepService.EventLogService.CreateOne(&models.EventLog{
-		Type: models.PingSweep,
+		Type:            models.PingSweep,
 		DurationSeconds: &durationInSeconds,
 	})
 	if err != nil {
@@ -413,10 +413,10 @@ func (sm *ScanManager) runSingleScan() {
 type ScanErrorType string
 
 const (
-	AlreadyRunning   ScanErrorType = "already_running"
-	NotRunning       ScanErrorType = "not_running"
-	NetworkNotFound  ScanErrorType = "network_not_found"
-	NoNetworks       ScanErrorType = "no_networks"
+	AlreadyRunning  ScanErrorType = "already_running"
+	NotRunning      ScanErrorType = "not_running"
+	NetworkNotFound ScanErrorType = "network_not_found"
+	NoNetworks      ScanErrorType = "no_networks"
 )
 
 // ScanError represents a scan-related error

--- a/backend/internal/web/handlers.go
+++ b/backend/internal/web/handlers.go
@@ -70,7 +70,6 @@ type NetworkInfo struct {
 	OfflineDevices int
 }
 
-
 func NewWebHandler(
 	deviceService *device.DeviceService,
 	eventLogService *eventlog.EventLogService,
@@ -178,8 +177,6 @@ func (h *WebHandler) Index(w http.ResponseWriter, r *http.Request) {
 	h.ServePage("dashboard")(w, r)
 }
 
-
-
 func (h *WebHandler) Devices(w http.ResponseWriter, r *http.Request) {
 	h.ServePage("devices")(w, r)
 }
@@ -262,7 +259,6 @@ func (h *WebHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/login", http.StatusSeeOther)
 }
 
-
 func (h *WebHandler) APIDeviceModal(w http.ResponseWriter, r *http.Request) {
 	session, _ := h.sessionStore.Get(r, "reconya-session")
 	user := h.getUserFromSession(session)
@@ -289,7 +285,7 @@ func (h *WebHandler) APIDeviceModal(w http.ResponseWriter, r *http.Request) {
 	screenshotsEnabled := h.settingsService.AreScreenshotsEnabled(fmt.Sprintf("%d", user.ID))
 
 	// Debug logging for IPv6 fields
-	log.Printf("Device %s IPv6 data: LinkLocal=%v, UniqueLocal=%v, Global=%v, Addresses=%v", 
+	log.Printf("Device %s IPv6 data: LinkLocal=%v, UniqueLocal=%v, Global=%v, Addresses=%v",
 		device.ID, device.IPv6LinkLocal, device.IPv6UniqueLocal, device.IPv6Global, device.IPv6Addresses)
 
 	// Return JSON response
@@ -400,7 +396,6 @@ func (h *WebHandler) APIDeleteDevice(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-
 func (h *WebHandler) APIPingInternet(w http.ResponseWriter, r *http.Request) {
 	session, _ := h.sessionStore.Get(r, "reconya-session")
 	if user := h.getUserFromSession(session); user == nil {
@@ -478,7 +473,6 @@ func (h *WebHandler) APIEventLogsTable(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
-
 
 // Helper methods
 func (h *WebHandler) getUserFromSession(session *sessions.Session) *models.User {
@@ -634,7 +628,7 @@ func (h *WebHandler) APIDeviceList(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusUnauthorized)
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": "Unauthorized",
+			"error":   "Unauthorized",
 			"success": false,
 		})
 		return
@@ -646,7 +640,7 @@ func (h *WebHandler) APIDeviceList(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": "Failed to retrieve devices",
+			"error":   "Failed to retrieve devices",
 			"success": false,
 		})
 		return
@@ -693,14 +687,14 @@ func (h *WebHandler) APIDeviceList(w http.ResponseWriter, r *http.Request) {
 		"screenshotsEnabled": screenshotsEnabled,
 		"networks":           networkMap,
 		"activeNetworkId":    activeNetworkID,
-		"success":           true,
+		"success":            true,
 	}
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		log.Printf("Failed to encode JSON response in APIDeviceList: %v", err)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(map[string]interface{}{
-			"error": "Failed to encode response",
+			"error":   "Failed to encode response",
 			"success": false,
 		})
 	}
@@ -766,7 +760,7 @@ func (h *WebHandler) APINetworks(w http.ResponseWriter, r *http.Request) {
 		log.Printf("APINetworks: Error getting networks: %v", err)
 		networksSlice = []models.Network{} // Ensure it's an empty slice, not nil
 	}
-	
+
 	log.Printf("APINetworks: Retrieved %d networks from service", len(networksSlice))
 
 	// Convert to pointer slice for template
@@ -780,7 +774,7 @@ func (h *WebHandler) APINetworks(w http.ResponseWriter, r *http.Request) {
 
 	// Get scan state for network selection highlighting
 	scanState := h.scanManager.GetState()
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	response := map[string]interface{}{
 		"networks":  networks,
@@ -792,6 +786,29 @@ func (h *WebHandler) APINetworks(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// parseNetworkRangeForm reads the repeated cidr/cidr_label fields submitted by
+// the /networks page's repeatable range-row form. Blank CIDR rows (from an
+// empty trailing "add range" row) are dropped; labels are paired with cidrs
+// by position and default to "" if the arrays are uneven.
+func parseNetworkRangeForm(r *http.Request) (cidrs []string, labels []string) {
+	rawCidrs := r.Form["cidr"]
+	rawLabels := r.Form["cidr_label"]
+
+	for i, c := range rawCidrs {
+		c = strings.TrimSpace(c)
+		if c == "" {
+			continue
+		}
+		cidrs = append(cidrs, c)
+		label := ""
+		if i < len(rawLabels) {
+			label = strings.TrimSpace(rawLabels[i])
+		}
+		labels = append(labels, label)
+	}
+
+	return cidrs, labels
+}
 
 func (h *WebHandler) APICreateNetwork(w http.ResponseWriter, r *http.Request) {
 	session, _ := h.sessionStore.Get(r, "reconya-session")
@@ -807,29 +824,16 @@ func (h *WebHandler) APICreateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := strings.TrimSpace(r.FormValue("name"))
-	cidr := strings.TrimSpace(r.FormValue("cidr"))
+	cidrs, labels := parseNetworkRangeForm(r)
 	description := strings.TrimSpace(r.FormValue("description"))
-	
-	log.Printf("APICreateNetwork: Received request - name=%s, cidr=%s, description=%s", name, cidr, description)
 
-	// Validate CIDR
-	if cidr == "" {
+	log.Printf("APICreateNetwork: Received request - name=%s, cidrs=%v, description=%s", name, cidrs, description)
+
+	if err := models.ValidateNetworkRanges(cidrs); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]interface{}{
 			"success": false,
-			"error": "CIDR address is required",
-		}
-		json.NewEncoder(w).Encode(response)
-		return
-	}
-
-	// Validate CIDR format
-	_, _, err := net.ParseCIDR(cidr)
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		response := map[string]interface{}{
-			"success": false,
-			"error": "Invalid CIDR format. Please use format like 192.168.1.0/24",
+			"error":   err.Error(),
 		}
 		json.NewEncoder(w).Encode(response)
 		return
@@ -837,13 +841,13 @@ func (h *WebHandler) APICreateNetwork(w http.ResponseWriter, r *http.Request) {
 
 	// Create network
 	log.Printf("APICreateNetwork: Calling networkService.Create")
-	network, err := h.networkService.Create(name, cidr, description)
+	network, err := h.networkService.Create(name, cidrs, labels, description)
 	if err != nil {
 		log.Printf("APICreateNetwork: Error creating network: %v", err)
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]interface{}{
 			"success": false,
-			"error": fmt.Sprintf("Failed to create network: %v", err),
+			"error":   fmt.Sprintf("Failed to create network: %v", err),
 		}
 		json.NewEncoder(w).Encode(response)
 		return
@@ -882,39 +886,26 @@ func (h *WebHandler) APIUpdateNetwork(w http.ResponseWriter, r *http.Request) {
 	}
 
 	name := strings.TrimSpace(r.FormValue("name"))
-	cidr := strings.TrimSpace(r.FormValue("cidr"))
+	cidrs, labels := parseNetworkRangeForm(r)
 	description := strings.TrimSpace(r.FormValue("description"))
 
-	// Validate CIDR
-	if cidr == "" {
+	if err := models.ValidateNetworkRanges(cidrs); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]interface{}{
 			"success": false,
-			"error": "CIDR address is required",
-		}
-		json.NewEncoder(w).Encode(response)
-		return
-	}
-
-	// Validate CIDR format
-	_, _, err := net.ParseCIDR(cidr)
-	if err != nil {
-		w.Header().Set("Content-Type", "application/json")
-		response := map[string]interface{}{
-			"success": false,
-			"error": "Invalid CIDR format. Please use format like 192.168.1.0/24",
+			"error":   err.Error(),
 		}
 		json.NewEncoder(w).Encode(response)
 		return
 	}
 
 	// Update network
-	network, err := h.networkService.Update(networkID, name, cidr, description)
+	network, err := h.networkService.Update(networkID, name, cidrs, labels, description)
 	if err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]interface{}{
 			"success": false,
-			"error": fmt.Sprintf("Failed to update network: %v", err),
+			"error":   fmt.Sprintf("Failed to update network: %v", err),
 		}
 		json.NewEncoder(w).Encode(response)
 		return
@@ -958,7 +949,7 @@ func (h *WebHandler) APIDeleteNetwork(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			response := map[string]interface{}{
 				"success": false,
-				"error": "Cannot delete network: a scan is currently running on this network. Please stop the scan first.",
+				"error":   "Cannot delete network: a scan is currently running on this network. Please stop the scan first.",
 			}
 			json.NewEncoder(w).Encode(response)
 			return
@@ -971,7 +962,7 @@ func (h *WebHandler) APIDeleteNetwork(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]interface{}{
 			"success": false,
-			"error": "Network not found",
+			"error":   "Network not found",
 		}
 		json.NewEncoder(w).Encode(response)
 		return
@@ -983,7 +974,7 @@ func (h *WebHandler) APIDeleteNetwork(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]interface{}{
 			"success": false,
-			"error": fmt.Sprintf("Failed to check network devices: %v", err),
+			"error":   fmt.Sprintf("Failed to check network devices: %v", err),
 		}
 		json.NewEncoder(w).Encode(response)
 		return
@@ -993,7 +984,7 @@ func (h *WebHandler) APIDeleteNetwork(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]interface{}{
 			"success": false,
-			"error": fmt.Sprintf("Cannot delete network: %d devices are still using this network. Please remove or reassign devices first.", deviceCount),
+			"error":   fmt.Sprintf("Cannot delete network: %d devices are still using this network. Please remove or reassign devices first.", deviceCount),
 		}
 		json.NewEncoder(w).Encode(response)
 		return
@@ -1010,7 +1001,7 @@ func (h *WebHandler) APIDeleteNetwork(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		response := map[string]interface{}{
 			"success": false,
-			"error": errorMsg,
+			"error":   errorMsg,
 		}
 		json.NewEncoder(w).Encode(response)
 		return
@@ -1030,8 +1021,64 @@ func (h *WebHandler) APIDeleteNetwork(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(response)
 }
 
+// APIToggleNetworkRange flips a range's active flag, including or excluding
+// it from future scans. The range keeps its scan history either way.
+func (h *WebHandler) APIToggleNetworkRange(w http.ResponseWriter, r *http.Request) {
+	session, _ := h.sessionStore.Get(r, "reconya-session")
+	user := h.getUserFromSession(session)
+	if user == nil {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
 
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
 
+	vars := mux.Vars(r)
+	networkID := vars["id"]
+	rangeID := vars["rangeId"]
+
+	network, err := h.networkService.FindByID(networkID)
+	if err != nil || network == nil {
+		http.Error(w, "Network not found", http.StatusNotFound)
+		return
+	}
+
+	var target *models.NetworkRange
+	for i := range network.Ranges {
+		if network.Ranges[i].ID == rangeID {
+			target = &network.Ranges[i]
+			break
+		}
+	}
+	if target == nil {
+		http.Error(w, "Range not found", http.StatusNotFound)
+		return
+	}
+
+	if err := h.networkService.SetRangeActive(rangeID, !target.Active); err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   fmt.Sprintf("Failed to update range: %v", err),
+		})
+		return
+	}
+
+	updated, err := h.networkService.FindByID(networkID)
+	if err != nil || updated == nil {
+		http.Error(w, "Network not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"success": true,
+		"network": updated,
+	})
+}
 
 // APIScanStatus returns the current scan status
 func (h *WebHandler) APIScanStatus(w http.ResponseWriter, r *http.Request) {
@@ -1050,7 +1097,7 @@ func (h *WebHandler) APIScanStatus(w http.ResponseWriter, r *http.Request) {
 // APIScanStart starts scanning a network
 func (h *WebHandler) APIScanStart(w http.ResponseWriter, r *http.Request) {
 	log.Printf("APIScanStart: Request received, method=%s", r.Method)
-	
+
 	session, _ := h.sessionStore.Get(r, "reconya-session")
 	user := h.getUserFromSession(session)
 	if user == nil {
@@ -1061,7 +1108,7 @@ func (h *WebHandler) APIScanStart(w http.ResponseWriter, r *http.Request) {
 
 	networkID := r.FormValue("network-selector")
 	log.Printf("APIScanStart: Network ID from form: '%s'", networkID)
-	
+
 	if networkID == "" {
 		log.Printf("APIScanStart: No network ID provided")
 		w.Header().Set("Content-Type", "application/json")
@@ -1188,7 +1235,6 @@ func (h *WebHandler) APIScanControl(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-
 // APIScanSelectNetwork sets the selected network (without starting scan)
 // APIDashboardMetrics returns JSON data for dashboard metrics
 func (h *WebHandler) APIDashboardMetrics(w http.ResponseWriter, r *http.Request) {
@@ -1218,7 +1264,7 @@ func (h *WebHandler) APIDashboardMetrics(w http.ResponseWriter, r *http.Request)
 				devices[i] = &devicesSlice[i]
 			}
 		}
-		networkCIDR = currentNetwork.CIDR
+		networkCIDR = currentNetwork.GetDisplayName()
 	} else {
 		// If no network is selected, show all devices
 		devices, err = h.deviceService.FindAll()
@@ -1288,13 +1334,13 @@ func (h *WebHandler) APIDashboardMetrics(w http.ResponseWriter, r *http.Request)
 	}
 
 	metrics := map[string]interface{}{
-		"networkRange":    networkCIDR,
-		"publicIP":        publicIP,
-		"location":        location,
-		"devicesFound":    len(devices),
-		"devicesOnline":   networkMapData.NetworkInfo.OnlineDevices,
-		"devicesOffline":  networkMapData.NetworkInfo.OfflineDevices,
-		"saturation":      saturation,
+		"networkRange":   networkCIDR,
+		"publicIP":       publicIP,
+		"location":       location,
+		"devicesFound":   len(devices),
+		"devicesOnline":  networkMapData.NetworkInfo.OnlineDevices,
+		"devicesOffline": networkMapData.NetworkInfo.OfflineDevices,
+		"saturation":     saturation,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1360,7 +1406,6 @@ func (h *WebHandler) APIAbout(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-
 // APISettings returns the settings page
 func (h *WebHandler) APISettings(w http.ResponseWriter, r *http.Request) {
 	session, _ := h.sessionStore.Get(r, "reconya-session")
@@ -1407,7 +1452,7 @@ func (h *WebHandler) APISettingsScreenshots(w http.ResponseWriter, r *http.Reque
 	// Parse the enabled parameter - checkbox sends value when checked, nothing when unchecked
 	enabledStr := r.FormValue("screenshots_enabled")
 	enabled := enabledStr == "true" || enabledStr == "on"
-	
+
 	log.Printf("Screenshot settings update: enabled=%s, parsed=%v", enabledStr, enabled)
 
 	// Update settings
@@ -1428,7 +1473,7 @@ func (h *WebHandler) APISettingsScreenshots(w http.ResponseWriter, r *http.Reque
 	}
 
 	log.Printf("Updated screenshot settings for user %d: enabled=%v", user.ID, enabled)
-	
+
 	// Return JSON success response
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
@@ -1486,7 +1531,7 @@ func (h *WebHandler) APINetworkSuggestion(w http.ResponseWriter, r *http.Request
 	name := fmt.Sprintf("Network %s", cidr)
 	description := "Auto-detected network"
 
-	network, err := h.networkService.Create(name, cidr, description)
+	network, err := h.networkService.Create(name, []string{cidr}, nil, description)
 	if err != nil {
 		log.Printf("Failed to create suggested network %s: %v", cidr, err)
 		http.Error(w, fmt.Sprintf("Failed to create network: %v", err), http.StatusInternalServerError)
@@ -1509,8 +1554,6 @@ func (h *WebHandler) APINetworkSuggestion(w http.ResponseWriter, r *http.Request
 func (h *WebHandler) getVersion() string {
 	return h.version
 }
-
-
 
 // templateFuncMap returns the helpers available to the HTML templates.
 // Extracted from NewWebHandler so the helpers can be unit-tested directly.

--- a/backend/internal/web/router.go
+++ b/backend/internal/web/router.go
@@ -45,6 +45,7 @@ func (h *WebHandler) SetupRoutes() *mux.Router {
 	api.HandleFunc("/networks", h.APICreateNetwork).Methods("POST")
 	api.HandleFunc("/networks/{id:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}", h.APIUpdateNetwork).Methods("PUT")
 	api.HandleFunc("/networks/{id:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}", h.APIDeleteNetwork).Methods("DELETE")
+	api.HandleFunc("/networks/{id:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/ranges/{rangeId:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}}/toggle", h.APIToggleNetworkRange).Methods("POST")
 
 	// Scan management endpoints
 	api.HandleFunc("/scan/status", h.APIScanStatus).Methods("GET")

--- a/backend/models/network.go
+++ b/backend/models/network.go
@@ -16,17 +16,57 @@ const (
 )
 
 type Network struct {
-	ID             string        `bson:"_id,omitempty" json:"id"`
-	Name           string        `bson:"name" json:"name"`
-	CIDR           string        `bson:"cidr" json:"cidr"`
-	IPv6Prefix     *string       `bson:"ipv6_prefix,omitempty" json:"ipv6_prefix,omitempty"`
-	AddressFamily  AddressFamily `bson:"address_family" json:"address_family"`
-	Description    string        `bson:"description" json:"description"`
-	Status         string        `bson:"status" json:"status"`
-	LastScannedAt  *time.Time    `bson:"last_scanned_at" json:"last_scanned_at"`
-	DeviceCount    int           `bson:"device_count" json:"device_count"`
-	CreatedAt      time.Time     `bson:"created_at" json:"created_at"`
-	UpdatedAt      time.Time     `bson:"updated_at" json:"updated_at"`
+	ID            string         `bson:"_id,omitempty" json:"id"`
+	Name          string         `bson:"name" json:"name"`
+	CIDR          string         `bson:"cidr" json:"cidr"`
+	IPv6Prefix    *string        `bson:"ipv6_prefix,omitempty" json:"ipv6_prefix,omitempty"`
+	AddressFamily AddressFamily  `bson:"address_family" json:"address_family"`
+	Description   string         `bson:"description" json:"description"`
+	Status        string         `bson:"status" json:"status"`
+	LastScannedAt *time.Time     `bson:"last_scanned_at" json:"last_scanned_at"`
+	DeviceCount   int            `bson:"device_count" json:"device_count"`
+	Ranges        []NetworkRange `bson:"ranges,omitempty" json:"ranges"`
+	CreatedAt     time.Time      `bson:"created_at" json:"created_at"`
+	UpdatedAt     time.Time      `bson:"updated_at" json:"updated_at"`
+}
+
+// NetworkRange is one IPv4 CIDR range scoped under a Network. A Network can
+// own several ranges so scans target the real subnets in use instead of a
+// covering supernet.
+type NetworkRange struct {
+	ID            string     `json:"id"`
+	NetworkID     string     `json:"network_id"`
+	CIDR          string     `json:"cidr"`
+	Label         string     `json:"label"`
+	Active        bool       `json:"active"`
+	LastScannedAt *time.Time `json:"last_scanned_at"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+// ActiveRanges returns the ranges eligible for scanning.
+func (n *Network) ActiveRanges() []NetworkRange {
+	active := make([]NetworkRange, 0, len(n.Ranges))
+	for _, r := range n.Ranges {
+		if r.Active {
+			active = append(active, r)
+		}
+	}
+	return active
+}
+
+// ValidateNetworkRanges validates a set of CIDR strings intended for a
+// network's ranges.
+func ValidateNetworkRanges(cidrs []string) error {
+	if len(cidrs) == 0 {
+		return fmt.Errorf("at least one CIDR range is required")
+	}
+	for _, cidr := range cidrs {
+		if _, _, err := net.ParseCIDR(cidr); err != nil {
+			return fmt.Errorf("invalid CIDR %q: %w", cidr, err)
+		}
+	}
+	return nil
 }
 
 func (n *Network) IsIPv4Enabled() bool {
@@ -64,7 +104,7 @@ func (n *Network) ValidateNetworkAddresses() error {
 			return fmt.Errorf("invalid IPv4 CIDR: %w", err)
 		}
 	}
-	
+
 	if n.IsIPv6Enabled() {
 		if n.IPv6Prefix == nil || *n.IPv6Prefix == "" {
 			return fmt.Errorf("IPv6 prefix is required for IPv6 or dual-stack networks")
@@ -73,7 +113,7 @@ func (n *Network) ValidateNetworkAddresses() error {
 			return fmt.Errorf("invalid IPv6 prefix: %w", err)
 		}
 	}
-	
+
 	return nil
 }
 
@@ -81,35 +121,53 @@ func (n *Network) ContainsIPv4(ip string) bool {
 	if !n.IsIPv4Enabled() {
 		return false
 	}
-	
-	_, ipNet, err := net.ParseCIDR(n.CIDR)
-	if err != nil {
-		return false
-	}
-	
+
 	testIP := net.ParseIP(ip)
 	if testIP == nil {
 		return false
 	}
-	
-	return ipNet.Contains(testIP)
+
+	cidrs := n.rangeCIDRs()
+	if len(cidrs) == 0 {
+		cidrs = []string{n.CIDR}
+	}
+
+	for _, cidr := range cidrs {
+		_, ipNet, err := net.ParseCIDR(cidr)
+		if err != nil {
+			continue
+		}
+		if ipNet.Contains(testIP) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (n *Network) rangeCIDRs() []string {
+	cidrs := make([]string, 0, len(n.Ranges))
+	for _, r := range n.Ranges {
+		cidrs = append(cidrs, r.CIDR)
+	}
+	return cidrs
 }
 
 func (n *Network) ContainsIPv6(ip string) bool {
 	if !n.IsIPv6Enabled() || n.IPv6Prefix == nil {
 		return false
 	}
-	
+
 	_, ipNet, err := net.ParseCIDR(*n.IPv6Prefix)
 	if err != nil {
 		return false
 	}
-	
+
 	testIP := net.ParseIP(ip)
 	if testIP == nil {
 		return false
 	}
-	
+
 	return ipNet.Contains(testIP)
 }
 
@@ -117,15 +175,26 @@ func (n *Network) GetDisplayName() string {
 	if n.Name != "" {
 		return n.Name
 	}
-	
+
 	if n.IsDualStack() {
 		return fmt.Sprintf("%s + %s", n.CIDR, n.GetIPv6Prefix())
 	}
-	
+
 	if n.IsIPv6Enabled() {
 		return n.GetIPv6Prefix()
 	}
-	
+
+	active := n.ActiveRanges()
+	if len(active) > 1 {
+		if len(active) == 2 {
+			return fmt.Sprintf("%s + %s", active[0].CIDR, active[1].CIDR)
+		}
+		return fmt.Sprintf("%s +%d more", active[0].CIDR, len(active)-1)
+	}
+	if len(active) == 1 {
+		return active[0].CIDR
+	}
+
 	return n.CIDR
 }
 

--- a/backend/models/network_test.go
+++ b/backend/models/network_test.go
@@ -1,0 +1,90 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func multiRangeNetwork() *Network {
+	return &Network{
+		ID:            "net-1",
+		AddressFamily: AddressFamilyIPv4,
+		Ranges: []NetworkRange{
+			{ID: "r1", CIDR: "10.0.1.0/24", Active: true},
+			{ID: "r2", CIDR: "10.0.2.0/24", Active: false},
+			{ID: "r3", CIDR: "10.0.3.0/24", Active: true},
+		},
+	}
+}
+
+func TestNetwork_ActiveRanges(t *testing.T) {
+	n := multiRangeNetwork()
+
+	active := n.ActiveRanges()
+
+	assert.Len(t, active, 2)
+	assert.Equal(t, "10.0.1.0/24", active[0].CIDR)
+	assert.Equal(t, "10.0.3.0/24", active[1].CIDR)
+}
+
+func TestNetwork_ContainsIPv4_AcrossRanges(t *testing.T) {
+	n := multiRangeNetwork()
+
+	assert.True(t, n.ContainsIPv4("10.0.1.5"))
+	assert.True(t, n.ContainsIPv4("10.0.2.5"), "inactive ranges still count as owned addresses")
+	assert.True(t, n.ContainsIPv4("10.0.3.5"))
+	assert.False(t, n.ContainsIPv4("10.0.4.5"))
+}
+
+func TestNetwork_ContainsIPv4_FallsBackToLegacyCIDR(t *testing.T) {
+	n := &Network{
+		AddressFamily: AddressFamilyIPv4,
+		CIDR:          "192.168.1.0/24",
+	}
+
+	assert.True(t, n.ContainsIPv4("192.168.1.42"))
+	assert.False(t, n.ContainsIPv4("10.0.0.1"))
+}
+
+func TestNetwork_GetDisplayName(t *testing.T) {
+	named := multiRangeNetwork()
+	named.Name = "Office LAN"
+	assert.Equal(t, "Office LAN", named.GetDisplayName())
+
+	twoRanges := &Network{
+		AddressFamily: AddressFamilyIPv4,
+		Ranges: []NetworkRange{
+			{CIDR: "10.0.1.0/24", Active: true},
+			{CIDR: "10.0.2.0/24", Active: true},
+		},
+	}
+	assert.Equal(t, "10.0.1.0/24 + 10.0.2.0/24", twoRanges.GetDisplayName())
+
+	threeRanges := &Network{
+		AddressFamily: AddressFamilyIPv4,
+		Ranges: []NetworkRange{
+			{CIDR: "10.0.1.0/24", Active: true},
+			{CIDR: "10.0.2.0/24", Active: true},
+			{CIDR: "10.0.3.0/24", Active: true},
+		},
+	}
+	assert.Equal(t, "10.0.1.0/24 +2 more", threeRanges.GetDisplayName())
+
+	single := &Network{
+		AddressFamily: AddressFamilyIPv4,
+		Ranges:        []NetworkRange{{CIDR: "10.0.1.0/24", Active: true}},
+	}
+	assert.Equal(t, "10.0.1.0/24", single.GetDisplayName())
+
+	legacy := &Network{AddressFamily: AddressFamilyIPv4, CIDR: "10.0.1.0/24"}
+	assert.Equal(t, "10.0.1.0/24", legacy.GetDisplayName())
+}
+
+func TestValidateNetworkRanges(t *testing.T) {
+	assert.NoError(t, ValidateNetworkRanges([]string{"10.0.1.0/24", "10.0.2.0/24"}))
+	assert.Error(t, ValidateNetworkRanges(nil))
+	assert.Error(t, ValidateNetworkRanges([]string{}))
+	assert.Error(t, ValidateNetworkRanges([]string{"not-a-cidr"}))
+	assert.Error(t, ValidateNetworkRanges([]string{"10.0.1.0/24", "garbage"}))
+}

--- a/backend/tests/testutils/fixtures.go
+++ b/backend/tests/testutils/fixtures.go
@@ -13,7 +13,7 @@ func CreateTestDevice() *models.Device {
 	hostname := "test-device"
 	vendor := "Test Vendor"
 	now := time.Now()
-	
+
 	return &models.Device{
 		ID:        uuid.New().String(),
 		Name:      "Test Device",
@@ -34,9 +34,37 @@ func CreateTestDeviceWithIP(ip string) *models.Device {
 }
 
 func CreateTestNetwork() *models.Network {
+	return CreateTestNetworkWithRanges("192.168.1.0/24")
+}
+
+// CreateTestNetworkWithRanges builds a network owning one range per cidr
+// given, all active. network.CIDR mirrors the first range for callers that
+// still read the legacy single-CIDR field.
+func CreateTestNetworkWithRanges(cidrs ...string) *models.Network {
+	now := time.Now()
+	id := uuid.New().String()
+
+	ranges := make([]models.NetworkRange, len(cidrs))
+	for i, cidr := range cidrs {
+		ranges[i] = models.NetworkRange{
+			ID:        uuid.New().String(),
+			NetworkID: id,
+			CIDR:      cidr,
+			Active:    true,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+	}
+
+	cidr := ""
+	if len(cidrs) > 0 {
+		cidr = cidrs[0]
+	}
+
 	return &models.Network{
-		ID:   uuid.New().String(),
-		CIDR: "192.168.1.0/24",
+		ID:     id,
+		CIDR:   cidr,
+		Ranges: ranges,
 	}
 }
 
@@ -54,7 +82,7 @@ func CreateTestEventLog(deviceID string) *models.EventLog {
 func CreateTestSystemStatus() *models.SystemStatus {
 	publicIP := "203.0.113.1"
 	now := time.Now()
-	
+
 	return &models.SystemStatus{
 		LocalDevice: *CreateTestDevice(),
 		NetworkID:   uuid.New().String(),

--- a/docs/00-network-scanning.md
+++ b/docs/00-network-scanning.md
@@ -1,0 +1,67 @@
+# Network Scanning
+
+Device discovery: how a "scan" actually runs, how the sweep decides a host is alive, and how IPv6 passive monitoring works. Port scanning (a separate, per-device pass) is covered in [02-port-scanning.md](02-port-scanning.md).
+
+## Network Model and Selection
+
+`models.Network` (`backend/models/network.go`) is mostly just `CIDR` plus display metadata (`Name`, `Description`, `Status`, `LastScannedAt`, `DeviceCount`). It also has `IPv6Prefix`/`AddressFamily` fields and dual-stack helper methods, but nothing else in the codebase actually uses them for scan targeting: IPv6 discovery works off live neighbor-discovery data, not this field, and the "network to scan" is always the network's `CIDR`.
+
+`NetworkService.Create` is an unconditional upsert; `FindOrCreate` looks up by CIDR first and only creates on a miss. `Delete` (the HTTP handler, not the service) refuses to delete a network with a scan currently running against it or with any devices still attached, and translates the resulting SQLite foreign-key error into a friendlier message.
+
+**"Selected network" is scan-manager state, not a network property.** `scan.ScanManager` tracks `SelectedNetwork` (what the UI picked) separately from `CurrentNetwork` (what's actively being scanned right now); `GetSelectedOrCurrentNetwork()` returns whichever applies. At startup, the primary-NIC detection goroutine (below) preselects the network matching the machine's own LAN, so a scan started with no explicit selection targets the network the machine is actually on rather than whichever network row happens to sort first.
+
+## Starting and Stopping a Scan
+
+Scanning is **continuous, not one-shot per request**. `POST /api/scan/start` calls `ScanManager.StartScan(networkID)`, which sets state to running and launches a loop: it runs one sweep immediately, then repeats every 30 seconds on a ticker, until `POST /api/scan/stop` closes the stop channel. `GET /api/scan/status` just returns the manager's in-memory state; `GET /api/scan/control` returns that state plus the network list, for the console's scan-control widget. `POST /api/scan/select-network` only updates `SelectedNetwork` and does not start anything.
+
+Each sweep iteration (`runSingleScan`):
+
+1. Checks the stop signal (cooperative cancellation between steps, not context cancellation).
+2. Logs a `PingSweep` start event.
+3. Runs the actual sweep (`PingSweepService.ExecuteSweepScanCommand`, see below) against the network's CIDR.
+4. For every discovered device, calls `DeviceService.CreateOrUpdateWithDelta`. If the delta says the device is new or has newly-opened ports, fires the corresponding alert immediately (`RecordNewDevice`/`RecordNewPorts`), because this is the last point at which "first sighting" is knowable, the row is about to be overwritten in place. See [03-alerting.md](03-alerting.md).
+5. Logs a `DeviceOnline` event per discovered device, and enqueues devices eligible for a port scan (`DeviceService.EligibleForPortScan`) as background goroutines.
+6. Logs a second `PingSweep` event carrying the actual elapsed duration for this iteration (measured fresh each pass, not against the session's overall start time, which would otherwise grow by 30 seconds on every iteration).
+7. Runs alert evaluation against **all** devices, not just this network's, since auto-resolve is scoped per rule; evaluating a subset would incorrectly resolve valid findings that belong to networks not part of this sweep.
+
+The reported "scan count" (`/api/scan/status`) is not the in-memory loop counter, it's a live count of completed `PingSweep` events in the database, specifically so the number doesn't jump around whenever a scan starts or stops.
+
+## The Ping Sweep
+
+Device discovery is a pure-Go implementation (`backend/internal/scanner`, `golang.org/x/net/icmp`), no `ping`, `nmap`, or `arp-scan` binaries are shelled out to for the sweep itself. `ScanNetwork(cidr)` enumerates every host address in the CIDR (excluding the network and broadcast addresses), invalidates the cached ARP table so a sweep never opens against entries left from a previous network, and fans the address list out to 50 concurrent worker goroutines.
+
+**A host counts as online only if corroborated**, per-IP:
+
+```
+online := icmpEchoReplyMatched || macResolvedViaARP || (tcpConnectSucceeded && !isOnLink(ip))
+```
+
+ICMP (tried unprivileged first via a UDP-datagram ICMP socket, falling back to a raw socket if that's unavailable) or a resolved ARP entry are trusted directly. A bare TCP connect success is trusted only when the IP is *off-link* (routed, not directly on the local subnet), because an on-link host that's actually alive must answer ARP, if only TCP succeeds for an on-link address, that's attributed to a middlebox (VPN, proxy, captive portal) intercepting the connection rather than a genuine live host, and is deliberately not counted, or an entire /24 behind such a device would look fully occupied.
+
+TCP probing tries 12 common ports (80, 443, 22, 21, 23, 25, 53, 135, 139, 445, 3389, 8080) in parallel with a short per-dial timeout, returning on the first success. MAC resolution reads the OS ARP table, and if that misses, sends a throwaway UDP packet to provoke an ARP resolution before re-checking. Hostname resolution tries, in order: reverse DNS, NetBIOS (`nmblookup`/`nbtstat`), mDNS (`<name>.local`), and HTTP banner headers (`Server`/`Location`), SNMP is present as an unimplemented stub.
+
+Vendor lookup uses a small built-in OUI map by default; if `VENDOR_LOOKUP_ONLINE_ENABLED=true`, unresolved OUIs fall back to a call to `api.macvendors.com` per discovered device, this is an outbound call and stays off by default, see [architecture.md](architecture.md#network-isolation).
+
+## Primary NIC Detection and Network Suggestions
+
+Runs on a 30-second ticker (`nicidentifier.NicIdentifierService.CheckForNewNetworks`), independently of whether a scan is active.
+
+**Primary NIC selection** skips down/loopback interfaces, classifies each remaining interface as Docker/VM-related (by interface name prefix, or by IP falling in a known container-network range like `172.16.0.0/12`) or a genuine host candidate, and prefers a candidate whose IP is in a common private range (`192.168.0.0/16`, `10.0.0.0/8`); a Docker interface is only used as a last resort if nothing else exists.
+
+**New-network detection**: for every up, non-loopback, non-point-to-point interface (VPN/tunnel interfaces like `utun*` are skipped, they carry a single host address, not a scannable LAN), for each IPv4 address not already a Docker/VM network and not a /31-or-smaller host-only network, the service derives the base CIDR and checks whether a matching `Network` row already exists.
+
+**Detection never creates a network row by itself**, it only writes a `NewNetworkDetected` event log ("Consider creating it for scanning") and makes the CIDR available via `GET /api/detected-networks`. Turning a suggestion into an actual scannable network requires an explicit `POST /api/network-suggestion` call (the console's network-suggestions UI), which calls `NetworkService.Create` with an auto-generated name and description.
+
+## IPv6 Passive Monitoring
+
+Generates no traffic by design: it reads the OS's existing neighbor-discovery cache (`ip -6 neigh show` on Linux, `ndp -an` on macOS) rather than sending any probes.
+
+**Lifecycle is coupled to the IPv4 scan session**, not independent: `IPv6MonitorService.Start()`/`Stop()` are called from `ScanManager.StartScan`/`StopScan`, so IPv6 monitoring only runs while an IPv4 scan session is active. On start, it auto-detects monitorable interfaces and guesses `/64` host prefixes from each interface's existing global addresses, then runs a small set of goroutines: one polling the NDP table every 30 seconds, one re-enumerating the local host's own interface addresses every 60 seconds, and a multicast-traffic monitor.
+
+A discovered IPv6 address is matched to an existing device by MAC first, then by IPv6 address; if a match is found, the address is attached and the device is marked online. **If no matching IPv4 device exists, the IPv6-only sighting is discarded, not persisted**, the code explicitly skips creating IPv6-only device rows to avoid malformed entries, pending proper dual-stack support.
+
+**Known documentation/code mismatch**: the README and `.env.example` describe `IPV6_MONITORING_ENABLED`, `IPV6_MONITOR_INTERFACES`, `IPV6_MONITOR_INTERVAL`, `IPV6_LINK_LOCAL_MONITORING`, and `IPV6_MULTICAST_MONITORING` as configurable. None of them are actually read anywhere in the Go source, `config.Config` has no IPv6 fields at all. In the running code, link-local and multicast monitoring are hardcoded on, interfaces/prefixes are always auto-detected, and the NDP poll interval is hardcoded to 30 seconds. Also, the multicast-traffic monitor is a placeholder that just blocks until the service stops, it logs that it "would require raw socket implementation" and does nothing. Don't treat those env vars as functional until this is reconciled; if you're asked to make IPv6 monitoring configurable, that wiring needs to be added from scratch, not fixed.
+
+## Broadcast/Network-Address Device Cleanup
+
+The sweep's IP list already excludes network and broadcast addresses, and `CreateOrUpdateWithDelta` refuses to persist a device at one going forward. `POST /api/devices/cleanup-network-broadcast` (`DeviceService.CleanupNetworkBroadcastDevices`) is a retroactive, manually-triggered fix-up for rows that predate that guard (e.g. from older code paths or the IPv6 monitor), nothing schedules it automatically, unlike the geolocation cache cleanup which runs on its own 6-hour ticker.

--- a/docs/01-device-identification.md
+++ b/docs/01-device-identification.md
@@ -1,0 +1,70 @@
+# Device Identification and Fingerprinting
+
+How a discovered host becomes a `Device` row: vendor lookup, hostname resolution, type classification, and the new-vs-update matching logic. See [00-network-scanning.md](00-network-scanning.md) for how a host gets discovered in the first place.
+
+## Device Model
+
+`models.Device` (`backend/models/device.go`) carries identity (`IPv4`, three IPv6 address fields plus `IPv6Addresses []string`, `MAC`, `Vendor`, `Hostname`), `Status` (`unknown`/`online`/`idle`/`offline`), `DeviceType`, an embedded `OS` struct (`Name`/`Version`/`Family`/`Confidence`), and scan-state timestamps (`LastSeenOnlineAt`, `PortScanStartedAt`, `PortScanEndedAt`, `WebScanEndedAt`).
+
+`DeviceType` declares 14 values (`router`, `switch`, `nas`, `printer`, `camera`, `server`, `workstation`, `laptop`, `mobile`, `iot`, `access_point`, `firewall`, `voip`, `unknown`), but the classification logic (below) can only ever produce 8 of them: `router`, `nas`, `printer`, `camera`, `mobile`, `server`, `workstation`, `voip`. `switch`, `laptop`, `iot`, `access_point`, and `firewall` exist in the enum with no code path that assigns them, they're either reserved for future heuristics or manual/API-only use, not something you'll see appear from a scan today.
+
+## MAC Vendor Lookup
+
+Two separate lookup paths exist, and they don't share data:
+
+**The one actually used during scanning** is a small hardcoded Go map (~40 entries: Apple, Cisco, Samsung, Intel, Netgear, etc.) inside `scanner.NativeScanner.lookupVendor`. If the MAC's OUI isn't in that map and `VENDOR_LOOKUP_ONLINE_ENABLED=true`, it falls back to `api.macvendors.com` (2s timeout) as a per-miss lookup, this is the outbound call gated by that env var, see [architecture.md](architecture.md#network-isolation).
+
+**`internal/oui.OUIService`** is a separate, much larger subsystem, it loads the full IEEE OUI registry from a local `oui.txt` file (optionally refreshed from `standards-oui.ieee.org` over plain HTTP when `OUI_DOWNLOAD_ENABLED=true`, at most every 30 days), and is constructed and initialized at startup. **It is effectively dead code at runtime**: the service is stored on `DeviceService` but nothing ever calls `LookupVendor` on it. If you're asked to improve vendor coverage, wiring this service's `LookupVendor` as a second-tier lookup (before or instead of the online API call) is the natural fix, don't assume it's already contributing just because it's initialized and populated.
+
+Also note: `oui.txt` itself is not committed to the repo (it's a runtime download target), so on a fresh checkout the bundled-database story only applies after a successful download, which requires `OUI_DOWNLOAD_ENABLED=true` at least once.
+
+## Hostname Resolution
+
+Runs per-IP during the ping sweep, only for hosts already determined online. Five methods are tried in order, first non-empty result wins:
+
+1. Reverse DNS (`net.DefaultResolver.LookupAddr`, 2s timeout)
+2. NetBIOS name query (shells out to `nmblookup`/`nbtstat`)
+3. mDNS (`<ip>.local`, 500ms timeout, resolved address must match the probed IP)
+4. SNMP system name, **not actually implemented**, this step always returns empty (it only checks port 161 reachability, never speaks SNMP)
+5. HTTP banner (HEAD to ports 80/8080/443/8443, hostname parsed out of a `Server` header or a redirect `Location`)
+
+Hostname only comes from this ping-sweep phase; a port scan pass does not re-resolve or overwrite it. The IPv6 monitor does its own separate, simpler reverse-DNS lookup for IPv6 global addresses.
+
+## OS Fingerprinting
+
+There is no active OS fingerprinting in this codebase, no TTL analysis, no banner-based OS detection, nothing resembling `nmap -O`. `FingerprintService.AnalyzeDevice` only does device-type classification (below); its one OS-aware step just *reads* `device.OS.Name` if it happens to already be set, but nothing anywhere in the codebase ever writes `os_name`/`os_version`/`os_family`/`os_confidence`. Those are real schema columns with a real struct field, but no writer, they're vestigial. Don't build logic that assumes `device.OS` is populated; treat any current appearance of OS data in the UI or API response as always empty in practice.
+
+## Device Type Classification
+
+`FingerprintService.AnalyzeDevice` runs five signal sources in a fixed priority order, each one only fills in the type if it's still `unknown` (vendor is the exception; it always sets first and can be overwritten by later steps that check `unknown`... in practice vendor runs first so it wins unless it found nothing):
+
+1. **Vendor string** (substring match, case-insensitive): cisco/juniper/netgear/linksys/d-link/tp-link → router; synology/qnap/drobo/netapp/seagate → nas; hp/canon/epson/brother/lexmark/xerox → printer; hikvision/dahua/axis/vivotek/foscam → camera; apple/samsung/lg/sony/huawei/xiaomi → mobile; dell/ibm/supermicro/intel → server.
+2. **Open ports** (open-state only): 161+23 both open → router; (139 or 445) and (548 or 2049) → nas; (80 or 443) and (21 or 22) → server; 515/631/9100 → printer; 554/8080 or an `rtsp` service label → camera; 5060/5061 or a `sip` service label → voip; port 22 open with 3 or fewer total open ports → server (an "SSH-only device" fallback).
+3. **Hostname substrings**: nas/synology/diskstation → nas; router/gateway/ap-/access-point → **router** (note: not `access_point`, despite that enum value existing); printer/print/hp-/canon- → printer; camera/cam/ipcam → camera; server/srv/web/db → server.
+4. **Web service signatures** (title/server header of any discovered web service, first match wins): synology/diskstation/qnap/"nas" → nas; router/"access point"/wireless/`lighttpd` server header → router; printer/"print server"/cups → printer; "ip camera"/webcam/surveillance → camera.
+5. **OS name** (only runs if `device.OS` is non-nil, which per above is effectively never true in current builds): windows/ubuntu/centos/rhel server strings → server; linux + embedded/openwrt/dd-wrt → router; ios/android → mobile; non-server windows or "mac os" or ubuntu → workstation.
+
+If nothing matched, the device defaults to **`workstation`**.
+
+## New vs Update: CreateOrUpdateWithDelta
+
+`DeviceService.CreateOrUpdateWithDelta` decides whether an incoming scan result is a brand-new device or an update to one already on record:
+
+1. Match by `IPv4` first.
+2. If no match **and** the incoming record has a MAC, fall back to matching by MAC, this is the DHCP-reassignment case: a device that kept its MAC but got a new IP is recognized as the same device rather than created as a new one, and the existing row's ID/IPv4/hostname/vendor/network/status are updated in place onto that existing record.
+3. If the user had set a `Name` or `Comment` on the existing record and the incoming scan data doesn't specify one, the existing value is preserved rather than cleared, a scan result never blanks out user-entered data.
+4. `CreatedAt` is preserved from the existing record; `UpdatedAt` always advances.
+
+**Why this matters for alerting**: the delta (`DeviceDelta{IsNew, NewPorts}`) is computed *before* the write, while the previous state is still known, because once the row is overwritten in place, "this device is new" and "this port just opened" are no longer recoverable from the database. See [03-alerting.md](03-alerting.md) for how `RecordNewDevice`/`RecordNewPorts` consume this. `NewPorts` is deliberately `nil` (not "everything closed") whenever either the previous or current port list is empty, a sweep that didn't run a port scan for this device carries no port information at all, and treating that as "all ports newly closed" would make every subsequent scan re-report the same ports as newly opened.
+
+`EligibleForPortScan` (used both to decide whether to schedule a port scan and referenced above in the port-scanning doc) becomes true again 30 seconds after the last completed port scan, or immediately if the device has never been port-scanned.
+
+## Fingerprinting Timing
+
+`PerformDeviceFingerprinting` runs on **every port scan pass**, not just for newly-discovered devices. Since a port scan runs on essentially every scan cycle for any device outside its 30-second cooldown, device-type classification effectively re-evaluates continuously for every known-online device, not once at discovery.
+
+## Device Name Cleanup
+
+`POST /api/devices/cleanup-names` blanks the `name` column on **every** device row in the database (leaves `comment`, `hostname`, and `vendor` untouched). This is a bulk reset, not a per-device targeted cleanup, useful after a period where auto-generated or incorrect names got written, but destructive to any manually-set names too. A second, near-identical `CleanupDeviceNames` handler exists in `internal/device/device_handlers.go` but is never mounted on a route, it's dead code left over from an earlier handler layout; don't be misled into thinking there are two different cleanup behaviors reachable from the API.
+
+Related, separate cleanup functions: `CleanupDuplicateDevices` (groups by MAC, keeps the most recently updated row, migrates any name/comment onto the keeper before deleting the rest) and `CleanupNetworkBroadcastDevices` (see [00-network-scanning.md](00-network-scanning.md#broadcastnetwork-address-device-cleanup)).

--- a/docs/02-port-scanning.md
+++ b/docs/02-port-scanning.md
@@ -1,0 +1,42 @@
+# Port Scanning and Web Services
+
+Per-device port scanning and the web-service/screenshot capture that follows it. See [00-network-scanning.md](00-network-scanning.md) for the ping sweep that discovers devices in the first place.
+
+## Port Scan
+
+"Top-ports" (per the README) means a fixed, hardcoded list of 89 well-known and common application ports (`scanner.GetDefaultPorts()`), not an nmap-style `--top-ports N` computation and not a CIDR/range concept. Every port scan checks the same 89 ports regardless of device type.
+
+**Two trigger paths, with different guarantees:**
+
+- **Automatic**, after a ping sweep: for each newly-processed device, if `DeviceService.EligibleForPortScan` returns true, the scan runs as a background goroutine.
+- **Manual**, via the console's RESCAN HOST button (`POST /api/devices/{id}/rescan`): runs the scan unconditionally, **bypassing the eligibility/cooldown check entirely**. A manual rescan always fires regardless of how recently the device was last scanned.
+
+Scanning itself is a pure-Go TCP connect scan (`backend/internal/scanner`, no `nmap` dependency), up to 100 concurrent workers, 500ms dial timeout per port. Every open port gets a service label from a static ~130-entry port-to-name table, applied unconditionally, it's a lookup table, not a live probe. A smaller hardcoded subset of ports (21, 22, 23, 25, 80, 110, 143, 443, 587, 993, 995, 3306, 5432, 6379, 8080) additionally gets a banner grab (HTTP HEAD for the HTTP-ish ports, raw read otherwise; TLS ports like 443/8443 are explicitly skipped, grabbing a TLS banner would need a handshake this scanner doesn't implement).
+
+**The banner is captured but never persisted**: `models.Port` has no banner field, so `PortScanService.ExecutePortScan` reads it and then discards it when building the `Port` rows it saves. If a future task needs banners visible in the UI or stored for alerting, that's new plumbing (add the column, thread it through), not a bug to "fix" in the grab logic itself.
+
+## Port Storage: Replace-All, Not Diff
+
+A device's port rows are only touched if the new scan found at least one open port: if it did, all existing rows for that device are deleted and the new set is bulk-inserted; if the scan found zero open ports, the old rows are left as-is. A device that briefly stops answering any port during one scan pass will not have its port list cleared, stale port rows can persist until a scan that finds at least one open port runs again. The alert-facing "newly opened ports" diff (`DeviceDelta.NewPorts`, see [03-alerting.md](03-alerting.md)) is computed separately, in memory, before this replace-all write happens, it is not derived from comparing database rows.
+
+## Cooldown
+
+`EligibleForPortScan` gates the automatic trigger only: a device is ineligible if `PortScanEndedAt + 30s` is still in the future. There is no equivalent gate on the manual rescan endpoint.
+
+**Quirk worth knowing:** `ResetPortScanCooldowns` (clears `port_scan_started_at`/`port_scan_ended_at`/`web_scan_ended_at` on every device) runs unconditionally on every backend startup, in `cmd/main.go`, right after schema init. The log line and the function's own doc comment both say "for development," but there is no environment check gating it, it runs the same way in a production build. Given the cooldown itself is only 30 seconds, the practical impact is small, but don't assume this call is dev-only if you're touching startup sequencing.
+
+**Also dead**: `Device.PortScanStartedAt` exists on the model and in the SQL read/write/reset paths, but nothing in the service layer ever assigns it. It is always `NULL` in practice, only `PortScanEndedAt` actually drives behavior.
+
+## Web Service Detection
+
+Runs after a port scan, over that device's now-populated `Ports`. A port is a web-service candidate if it's open and either its number is in a small hardcoded list (80, 443, 8080, 8443, 8000, 8008, 8081, 9000, 3000, 5000) or its service-name label contains "http" or "web". For each candidate, an HTTP GET (10s timeout, self-signed TLS certs accepted, response capped at 1MB) is attempted; only 2xx/3xx responses are kept, and the page `<title>` is extracted for HTML responses.
+
+Web service rows follow the same replace-all-if-nonempty persistence pattern as ports. The stored `port`/`protocol` for a web service are re-derived from the response URL string via crude substring matching (recognizes `:80`, `:443`, `:8080`, `:8443` only, defaulting to port 80 otherwise), not carried through directly from the scan.
+
+## Screenshots
+
+Backend priority order, first success wins: **chromedp (only in `-tags chromedp` builds) → Firefox headless → Chrome/Chromium headless → wkhtmltoimage → webkit2png (macOS)**. This differs from the order the README lists (chrome/chromium, firefox, wkhtmltoimage, webkit2png), Firefox is actually tried before Chrome in the real fallback chain. Chrome discovery tries several binary names (`google-chrome`, `chromium`, `chromium-browser`, `chrome`) plus known absolute install paths before giving up. Each exec-based backend gets a hard 15-second kill timeout; window size is 1280x1024 across all backends.
+
+A captured screenshot is written to a temp file under `/tmp/reconya-screenshots/`, immediately base64-encoded, and the temp file is deleted, so the `screenshot` column in `web_services` stores a **base64 PNG string**, nothing persists on disk after capture completes.
+
+**The screenshots-enabled setting does not actually control screenshot capture during scans.** `Settings.ScreenshotsEnabled` (default `true`, toggle at `/settings`) only affects what the frontend is told via API responses (whether to show a screenshot placeholder in the UI); `PortScanService`'s own internal `ScreenshotsEnabled` field is hardcoded `false` at construction ("disabled for automated scans to improve performance") and nothing in the codebase ever flips it to `true`. In the current build, scans always take the no-screenshot code path regardless of the settings toggle. If asked to make the setting actually control capture, that means wiring `PortScanService.ScreenshotsEnabled` to read the per-user setting, it is a missing connection, not a regression.

--- a/docs/03-alerting.md
+++ b/docs/03-alerting.md
@@ -1,0 +1,78 @@
+# Alerting
+
+Alert rules run in `backend/internal/alert/`. Pure detection logic (`rules.go`) is separated from persistence (`alert_service.go`), see [backend-patterns.md](backend-patterns.md#alert-rules-pattern). This doc covers what actually triggers an alert, how dedupe/state work, and the API surface.
+
+## Alert Model
+
+`models.Alert` (`backend/models/alert.go`): `ID`, `RuleID`, `DedupeKey` (never serialized, `json:"-"`), `Severity`, `Title`, `Detail`, `DeviceID *string`, `NetworkID *string`, `State`, `Occurrences int`, `FirstSeenAt`, `LastSeenAt`, `AckedAt *time.Time`, `ResolvedAt *time.Time`, `CreatedAt`, `UpdatedAt`.
+
+**State** (`AlertState`): `open`, `acked`, `resolved`. States are operator-controlled, not just a mirror of the underlying condition: rules re-emit the same finding on every evaluation pass, so state only changes when either the operator acts (ack) or the condition itself stops/resumes holding (resolve/reopen). See "Upsert and dedupe" below.
+
+**Severity** (`AlertSeverity`): `critical`, `warning`, `notice`, `info`, ranked in that order (unranked values sort last).
+
+## Rules
+
+Six rule IDs: `new_device`, `unidentified_host`, `duplicate_mac`, `new_port`, `risky_port`, `host_unreachable`. Four of them (`unidentified_host`, `duplicate_mac`, `risky_port`, `host_unreachable`) are "stateful" and re-evaluated from scratch on every pass; `new_device` and `new_port` are event-triggered one-shots. See [database.md](database.md#alerts-upsert-pattern) for why this split matters for the dedupe key.
+
+### unidentified_host
+
+Fires when a *non-offline* device has **all** of: no vendor string, no hostname, no user-assigned name, zero open ports, **and** a locally-administered (randomized) MAC bit set. A randomized MAC alone is normal (many devices randomize for privacy) and is not treated as suspicious by itself; it only counts alongside a total absence of any other identifying signal. Severity `critical`. Dedupe key: `unidentified_host:<device_id>`.
+
+### duplicate_mac
+
+Groups all *online* devices by normalized MAC (lowercased, separators stripped, must resolve to exactly 12 hex characters). Any MAC shared by two or more currently-online devices fires once, attached to the device with the lowest IP in the group. Offline devices are excluded from the comparison on purpose: a device that got reassigned a new DHCP lease leaves a stale offline row behind, and without this exclusion that row would collide with its own live replacement. Severity `critical`. Dedupe key: `duplicate_mac:<normalized_mac>`.
+
+### risky_port
+
+Fires per open port on an online device that matches a hardcoded list:
+
+| Port | Why it's flagged |
+|---|---|
+| 21 | FTP, credentials travel in clear text |
+| 23 | Telnet, credentials travel in clear text |
+| 445 | SMB, file sharing exposed to the whole segment |
+| 3389 | RDP, remote desktop exposed to the whole segment |
+| 5900 | VNC, remote desktop, frequently unauthenticated |
+| 9100 | JetDirect, raw printing, unauthenticated by design |
+
+Only ports currently in `open` state count; the same risky port sitting closed on a device does not fire. Severity `warning`. Dedupe key: `risky_port:<device_id>:<port>`.
+
+### host_unreachable
+
+Fires only for a device that is `offline` **and** has a recorded `LastSeenOnlineAt` (a device never seen online never fires this). The time since last-seen must be at least `ALERT_OFFLINE_THRESHOLD_HOURS` (env-configurable, default 6h) and, if set, no more than a fixed 7-day window, so a device gone for months doesn't re-trigger the same alert indefinitely on top of already being resolved. Severity `warning`. Dedupe key: `host_unreachable:<device_id>`.
+
+### new_device / new_port
+
+Not part of the stateful re-evaluation loop, they describe a moment, not an ongoing condition. Fired directly from `scan.ScanManager` right after `DeviceService.CreateOrUpdateWithDelta` reports `delta.IsNew` or a non-empty `delta.NewPorts`: `AlertService.RecordNewDevice` / `RecordNewPorts`. This is why the device-write path threads a `DeviceDelta` back to the caller instead of just returning the saved row: once the SQLite row is overwritten in place, "this device is new" and "this port just opened" cannot be recovered from the database afterward. Severity `critical` (new device) / dedupe key `new_device:<device_id>` and `new_port:<device_id>:<port>` respectively. A brand-new device never gets `new_port` alerts for its initial port set, only for ports that open on a later scan, since a first sighting's entire port list would otherwise be noise.
+
+## Evaluation Flow
+
+`AlertService.Evaluate` (mutex-guarded, so the ticker and a scan sweep can't run it concurrently):
+
+1. Load all devices and all networks (network lookup is best-effort, used only for CIDR labels).
+2. Run the four stateful `eval*` functions against that snapshot.
+3. Upsert every returned finding (see below), tracking which dedupe keys were live in this pass, per rule.
+4. For each stateful rule, auto-resolve any open/acked alert of that rule whose dedupe key was **not** in this pass's live set, the condition stopped holding.
+5. Expire one-shots: any `new_device`/`new_port` alert whose `last_seen_at` is more than 24 hours old gets marked `resolved`, purely on age, no explicit "un-new" condition exists.
+
+**Two triggers run `Evaluate`:**
+- A 1-minute ticker (`runAlertEvaluator` in `cmd/main.go`), for conditions that cross a threshold purely from elapsed time (`host_unreachable`, one-shot expiry) with no scan activity involved.
+- Once after every completed sweep in `scan.ScanManager`, evaluating **all** devices (not just the swept network), because auto-resolve is scoped per rule: evaluating a subset would incorrectly resolve valid findings belonging to networks that weren't part of this sweep.
+
+## Upsert and Dedupe
+
+Alerts are written via `INSERT ... ON CONFLICT(dedupe_key) DO UPDATE`, since rules re-emit their full finding set every pass rather than diffing against history. On conflict:
+
+- `severity`, `title`, `detail`, `device_id`, `network_id`, `last_seen_at`, `updated_at` always refresh to the latest values.
+- `state` is left alone, **unless** the existing row was `resolved`, in which case it flips back to `open`. This is deliberate: since rules re-emit their whole finding set after every pass, bumping an acked alert back to open on every re-fire would make acknowledgement pointless. A resolved alert whose condition returns is the one case that should reopen.
+- `occurrences` increments only on that resolved-to-open transition, it counts recurrences of a condition, not raw sightings.
+
+Net effect: acking an alert suppresses it indefinitely while the condition persists. If the condition later stops holding, auto-resolve (step 4 above) moves it to `resolved` regardless of prior ack state (its `WHERE` clause is simply "not already resolved"). If the condition then returns, the next upsert reopens it from `resolved` and bumps `occurrences`.
+
+## API
+
+All endpoints require an authenticated session.
+
+- `GET /api/alerts`, query params `state` (repeatable; defaults to `open,acked` if omitted), `severity` (repeatable, no default filter), `limit` (default 100). Response: `{alerts: [...], counts: AlertCounts, open_count: int}`. `counts` is always computed over open alerts only, regardless of the `state` filter applied to `alerts`. There is no `device_id` filter on this endpoint even though the underlying query supports one.
+- `POST /api/alerts/{id}/ack`, acknowledges one alert, `404` if the ID doesn't exist.
+- `POST /api/alerts/ack-all`, acknowledges every currently-`open` alert (already-acked or resolved rows are untouched); returns the count acknowledged.

--- a/docs/04-web-console.md
+++ b/docs/04-web-console.md
@@ -1,0 +1,53 @@
+# Web Console
+
+The server-rendered frontend: how the single-template page mechanism works, and the behavior of each console surface (dashboard/topology, devices, networks, logs, alerts, settings). See [code-conventions.md](code-conventions.md#frontend) for the file layout and [backend-patterns.md](backend-patterns.md#web-handler-pattern) for the handler pattern these all sit on top of.
+
+## One Template, Client-Rendered Content
+
+All six pages (`/`, `/devices`, `/networks`, `/logs`, `/alerts`, `/settings`) are served by the same handler factory, `h.ServePage(pageName)`, which renders a single parsed template, `backend/assets/templates/index.html`, passing `{Page: pageName, User: ...}`. `/login` is the only page with its own separate template (`standalone/login.html`), rendered outside this mechanism.
+
+The mechanism is a hybrid: the Go template picks which HTML *skeleton* to emit via `{{if eq .Page "devices"}}...{{else if ...}}` branches on `.Page`, but each branch just emits an empty placeholder container (e.g. a loading div). There are no HTMX attributes anywhere in the current template, an earlier htmx/radial-map/device-modal-based implementation was fully replaced; `templateFuncMap()` is deliberately empty. All actual content population is client-side JS reading `data-page` off the shell element and fetching JSON from `/api/*`. Keep this in mind if you're tempted to add HTMX back for a new page fragment, it would be reintroducing a pattern the rest of the console has moved away from; follow the JS-fetch-and-render convention instead.
+
+## Polling Cadence
+
+`console.js` defines the poll intervals used across the console (`POLL`): devices every 15s, dashboard metrics every 15s, scan status every 5s, event log every 20s, alerts every 15s, and a 3s internet-reachability ping. The scan-control widget's own runtime clock (elapsed sweep time) ticks independently every 1s on its own timer so it doesn't need a full state poll to advance visibly.
+
+## Dashboard / Topology Map (`/`)
+
+`APIDashboardMetrics` scopes to the currently selected/active network if one is set (else all devices), and returns device counts (found/online/offline), public IP + geolocation (fetched on demand if not cached), and a saturation percentage (`devices in range / total host addresses in the CIDR × 100`). Alert counts and scan status are deliberately not part of this payload, they come from their own endpoints and are polled separately.
+
+The topology map itself (`network-viz.js`) is a `<canvas>` (not SVG), fed by whatever the devices poll already fetched, there's no dedicated topology endpoint. Two layouts: TREE (gateway → core switch → one band per network sized by host count → hosts in rows) and RADIAL (one ring per network around a center gateway). Node shape encodes role (square = infrastructure, triangle = unidentified, circle = normal host) and fill color encodes status (green = online, dim green = idle, dark = offline, amber = unidentified). New nodes fly out from the gateway point over ~900ms when they first appear; the canvas runs its own animation loop independent of the poll cadence, so motion stays smooth between data refreshes.
+
+**Clicking a device node opens the side drawer, not a modal or dropdown.** The drawer (`#rc-drawer`, OVERVIEW/PORTS/HISTORY/NOTES tabs) is a persistent panel slid into view via a CSS class toggle on the shell, populated by fetching `/api/devices/{id}/modal` (named for a historical modal implementation; it now backs the drawer). `dialog.js` (the shared `#rc-dialog` popup) is reserved for things that genuinely interrupt: adding/editing/deleting a network and the About panel, it is explicitly not used for device inspection anymore.
+
+## Devices (`/devices`)
+
+`APIDeviceList` scopes results to the active network server-side (filters by `NetworkID` when one is selected), specifically so a response never leaks another network's device inventory to the client. Response includes the device list, the screenshots-enabled flag, and the network list for the network filter.
+
+Only `name` and `comment` are editable via `PUT /api/devices/{id}` (`APIUpdateDevice`); an empty string in the request means "leave unchanged," not "clear the field," there is currently no way to explicitly blank out a name/comment via this endpoint. Device deletion (`DELETE /api/devices/{id}`) logs a `DeviceDeleted` event before removing the row.
+
+## Networks (`/networks`)
+
+Table of networks (CIDR, name, description, host count, last-scanned, scanning state) with per-row edit/delete/scan actions and an "add network" action, all routed through the shared dialog for the add/edit form.
+
+**Detected-network suggestions are applied automatically, with no confirmation prompt.** Every 15 seconds, the console diffs `GET /api/detected-networks` against the existing network list and silently `POST`s any CIDR that's missing to `/api/network-suggestion`, auto-named `"Network <cidr>"`. This is a deliberate console-side behavior, not a bug, if you're asked to add a confirm-before-adding step, that's new UX, not a fix to existing behavior.
+
+## Logs (`/logs`)
+
+Full activity table via `GET /api/event-logs-table` (last 100 rows), polled every 20s. The dashboard's live event feed uses the smaller `GET /api/event-logs` (last 20), and a device's HISTORY drawer tab uses `GET /api/devices/{id}/events` (last 50 for that device). Event types are human-readable strings (`"Ping sweep"`, `"Device is now offline"`, `"New network detected"`, etc., see `models.EEventLogType`), not slugs, both the map's feed and the logs table switch on the literal string to choose an icon/color. The live feed collapses consecutive identical-type rows into a single "type ×N" entry client-side, so a burst of per-device events during a sweep doesn't flood the feed with duplicates.
+
+## Alerts (`/alerts` + dashboard tile)
+
+One `GET /api/alerts` fetch drives three surfaces: the top-bar summary tile, the feed panel (used both in the dashboard's dock and on the full `/alerts` page), and a critical-alert toast that surfaces the first not-yet-dismissed open critical alert. Toast dismissal is session-only client state, it is not an acknowledgement and does not touch the server; dismissing the toast just stops it from popping up again this session, the alert is still open server-side.
+
+Clicking an alert row with an attached device opens that device's drawer instead of acknowledging it; clicking a row with no device acknowledges it directly. The page-level "acknowledge all" action (present only on the full `/alerts` page) hits `POST /api/alerts/ack-all`. See [03-alerting.md](03-alerting.md) for what acknowledgement actually changes server-side.
+
+## Settings
+
+Only one setting is actually wired up: `screenshots_enabled`, via `POST /api/settings/screenshots`. The settings page also displays a read-only "fixed values" block (sweep interval, idle/offline thresholds, alert threshold, port-rescan cooldown) as hardcoded display strings, not fetched from the server, and two maintenance actions (`cleanup-names`, `cleanup-network-broadcast`) that POST directly to their respective endpoints. An earlier version of this page had `scan_interval`/`concurrent_scans` fields that no backend handler ever read, they were removed rather than left as dead controls, on the reasoning that a control that silently does nothing is worse than no control. Don't reintroduce settings fields without wiring a handler to actually consume them.
+
+## Authentication
+
+Single static credential pair from `.env` (no user table, no password hashing) checked against a `reconya-session` cookie (`gorilla/sessions`, 30-day expiry, HttpOnly). Page routes re-check the session on every full navigation/reload and redirect to `/login` on failure; `/api/*` handlers independently return a bare `401` with no redirect.
+
+**There is no client-side 401 interceptor.** If a session expires while the console is already open, the background polls (devices/metrics/scan/alerts/events) start failing silently (logged only to the browser devtools console); nothing redirects the user to `/login` until they trigger a full page navigation, at which point the server-side page-route check catches it. If you're asked to "fix" the console going stale after logout/session-expiry, this is the mechanism to add: a shared fetch wrapper that redirects on 401, there currently isn't one.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -1,0 +1,42 @@
+# Claude Memory & Preferences
+
+Preferences and patterns specific to working with Claude Code on reconYa. This file is git-tracked and applies to anyone (human or AI) working from this clone; personal cross-project preferences live in Claude Code's own memory, not here.
+
+---
+
+## Commit Message Preferences
+
+- **Do NOT add** `Co-authored-by` trailers.
+- **No em dashes** in commit messages, code, or any generated text.
+- No emojis in commit messages.
+- Keep messages short and imperative (see `git log` for style, e.g. `Fix phantom devices, cumulative sweep duration, and scan counter`, `Console rewrite, alert system, and correct default scan target`). No `feat:`/`fix:` conventional-commit prefixes in use.
+- There is no PR or issue template in `.github/`, write plain, direct descriptions.
+
+---
+
+## Scope
+
+- **Cloud/SaaS hosting is out of scope.** reconYa's core function (ICMP/ARP/port scanning) requires direct access to a local network, so a hosted multi-tenant version isn't a meaningful product direction. Don't propose cloud deployment or multi-tenant architecture as a monetization or scaling path.
+- **Outbound network calls default to off.** Any new integration that calls out to a third party (vendor lookup, geolocation, etc.) must be gated behind its own `false`-by-default config flag, see [architecture.md](architecture.md#network-isolation). This is a stated product property ("zero outbound calls by default"), not an oversight to "fix".
+
+---
+
+## Codebase Patterns to Remember
+
+- **No migration files.** Schema changes are appended to `db.InitializeSchema` in `backend/db/sqlite.go` as `CREATE TABLE IF NOT EXISTS` / `ALTER TABLE ADD COLUMN`, guarded so re-running is a no-op. See [database.md](database.md).
+- **`bson` struct tags in `backend/models/` are vestigial** (left over from a prior MongoDB backend). The database is SQLite-only now. Don't read their presence as evidence of a Mongo dependency, and don't feel obligated to keep adding them to new fields.
+- **Background goroutines recover from their own panics** and log rather than propagate, a bug in one periodic task (device updater, alert evaluator, ...) must never take down the process. Follow this shape for any new one; see [architecture.md](architecture.md#background-workers).
+- **Alert rules are pure functions** (`backend/internal/alert/rules.go`) separated from the I/O that persists them (`alert_service.go`). Keep new rules in that shape so they stay unit-testable without a database.
+- **No mocking framework.** Tests that need a database use a real, throwaway SQLite file via `testutils.SetupTestDatabase`. See [testing.md](testing.md).
+
+---
+
+## Release Workflow
+
+- `make release V=x.y.z` bumps `VERSION`, commits, and tags via `scripts/bump-version.sh`.
+- Push both the branch and the `vx.y.z` tag; `.github/workflows/release.yml` builds Linux (Zig cross-compile) and macOS (native, amd64+arm64) binaries and publishes them.
+
+---
+
+**Last Updated:** 2026-08-11
+**Maintained by:** Update as new patterns emerge or existing ones change.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,89 @@
+# Architecture Overview
+
+## Tech Stack
+
+- **Backend:** Go 1.25, standard `net/http` + [gorilla/mux](https://github.com/gorilla/mux) for routing
+- **Frontend:** Server-rendered HTML templates (`html/template`) + HTMX for partial updates, vanilla JS for the topology map and interactive widgets
+- **Database:** SQLite (via `mattn/go-sqlite3`, cgo required), WAL mode
+- **Sessions:** `gorilla/sessions`, cookie-based
+- **Embedding:** Templates, static assets, and the OUI vendor database are compiled into the binary with `//go:embed`, there is no separate frontend build step
+
+There is no API/frontend split in the SPA sense. `backend/internal/web` renders full pages and HTMX fragments from the same handler layer that owns the domain services.
+
+## Request Flow
+
+```
+Browser
+  │  GET/POST (page load, HTMX fragment, or /api/* call)
+  ▼
+middleware.LoggingMiddleware
+  ▼
+gorilla/mux Router (backend/internal/web/router.go)
+  │
+  ├─ Page routes ("/", "/devices", "/networks", ...) → h.ServePage(name)
+  │     renders backend/assets/templates/index.html against html/template
+  │
+  ├─ Auth routes ("/login", "/logout") → session cookie via gorilla/sessions
+  │
+  └─ /api/* routes → WebHandler methods (handlers.go, alert_handlers.go)
+        │
+        ▼
+     internal/<domain> services (device, network, alert, scan, portscan, ...)
+        │
+        ▼
+     db.RepositoryFactory → SQLite repositories (backend/db)
+        │
+        ▼
+     reconya.db (SQLite, WAL)
+```
+
+`WebHandler` (backend/internal/web/handlers.go) is the composition root for the web layer: `main.go` constructs every service, then wires them all into one `WebHandler` via `web.NewWebHandler(...)`, and `SetupRoutes()` attaches its methods to routes.
+
+## Background Workers
+
+`backend/cmd/main.go` starts several long-running goroutines alongside the HTTP server. They are the actual engine of the app, the web layer is mostly a view onto state these loops maintain:
+
+| Goroutine | Interval | Responsibility |
+|---|---|---|
+| `runDeviceUpdater` | 5s | Ages devices from online → idle → offline, writes event log transitions |
+| `runNetworkDetection` (`nicidentifier`) | 30s | Detects the primary NIC and suggests/creates networks for new interfaces |
+| `runGeolocationCacheCleanup` | 6h (+ once at startup) | Expires stale geolocation cache rows |
+| `runAlertEvaluator` (`internal/alert`) | 1m | Re-runs stateful alert rules that fire on elapsed time, not scan events |
+| `scan.ScanManager` (`internal/scan`) | on demand / selected network | Drives ping sweeps (`internal/pingsweep`), IPv6 monitoring (`internal/ipv6monitor`), and triggers alert evaluation after each sweep |
+| `portscan.PortScanService` | per-device, backgrounded from handlers | Runs port scans off the request path; results land via the device/event-log services |
+
+All of them recover from panics individually and log rather than crash the process; `main()` itself also recovers from a top-level panic and restarts.
+
+## Data Model Hierarchy
+
+```
+Network (CIDR)
+  └─ Device (IPv4/MAC/vendor/status/hostname)
+       ├─ Port (open ports, service, banner)
+       ├─ WebService (screenshot metadata for HTTP(S) ports)
+       └─ EventLog (status transitions, scan events, alerts)
+
+Alert (device- or network-scoped, acknowledgeable)
+SystemStatus (single-row: detected NIC, selected network, public IP/geo cache)
+Settings (single-row: user-configurable toggles)
+User (login credentials, currently a single admin account from env vars)
+```
+
+See [database.md](database.md) for the actual table definitions.
+
+## Authentication
+
+Single-user, credential-based login (`LOGIN_USERNAME` / `LOGIN_PASSWORD` from `.env`, no self-registration). A successful `/login` POST sets a `reconya-session` cookie via `gorilla/sessions`; `WebHandler.getUserFromSession` gates every mutating `/api/*` handler and the page routes redirect to `/login` when the session is missing.
+
+## Network Isolation
+
+By design, reconYa makes zero outbound network calls unless explicitly enabled. Every optional integration is a separate `bool` in `internal/config.Config`, defaulting to `false`:
+
+| Config field | Env var | Calls out to |
+|---|---|---|
+| `PublicIPLookupEnabled` | `PUBLIC_IP_LOOKUP_ENABLED` | api.ipify.org |
+| `GeolocationEnabled` | `GEOLOCATION_ENABLED` | ip-api.com |
+| `VendorLookupEnabled` | `VENDOR_LOOKUP_ONLINE_ENABLED` | api.macvendors.com |
+| `OUIDownloadEnabled` | `OUI_DOWNLOAD_ENABLED` | standards-oui.ieee.org |
+
+Keep this property intact when touching `internal/config`, `internal/oui`, `internal/nicidentifier`, or `internal/systemstatus`, a new outbound call needs its own opt-in flag, not an always-on default.

--- a/docs/backend-patterns.md
+++ b/docs/backend-patterns.md
@@ -1,0 +1,50 @@
+# Backend Patterns
+
+## Module Architecture
+
+Each concern lives in its own package under `backend/internal/<name>/`. There is no shared "controllers" or "services" top-level folder, each module owns its full vertical slice (service + optional handlers), and `backend/internal/web` is the only package that talks HTTP.
+
+A typical module (`backend/internal/device/`):
+
+```
+device_service.go    # DeviceService: business logic, talks to db.DeviceRepository
+device_handlers.go   # thin handler helpers used by web.WebHandler, if any
+device_updater.go    # the periodic status-aging logic invoked from cmd/main.go
+```
+
+Modules depend on each other by taking constructor arguments, not by reaching into globals, e.g. `device.NewDeviceService` takes a `*network.NetworkService`, `alert.NewAlertService` takes `device.DeviceReader`/`network.NetworkReader` interfaces it defines itself. `backend/cmd/main.go` is the single place that constructs every service in dependency order and wires them together; nothing else does this. When adding a module, follow that pattern: define what you need from other packages as a small interface in your own package rather than importing their concrete service type where a narrower interface will do (see `alert.DeviceReader` in `alert_service.go`).
+
+## Adding a New Module
+
+1. Create `backend/internal/<name>/<name>_service.go` with a `<Name>Service` struct and a `New<Name>Service(...)` constructor that takes its dependencies (a repository, other services it needs, `*config.Config`) as arguments.
+2. If it needs persistence, add the repository interface to `backend/db/repository.go` and the SQLite implementation to `backend/db/sqlite_repositories.go` (see [database.md](database.md)).
+3. Wire it up in `backend/cmd/main.go`: construct the repository via `repoFactory`, construct the service, pass it to anything downstream that needs it (usually `web.NewWebHandler`).
+4. If it needs HTTP endpoints, add handler methods on `WebHandler` in `backend/internal/web/handlers.go` (or a new `<name>_handlers.go` in that package, following `alert_handlers.go`) and register routes in `backend/internal/web/router.go`.
+5. If it needs a periodic background pass, add a `run<Name>` goroutine function in `main.go` following the existing ones (own panic recovery, `ticker`, `done` channel for shutdown).
+
+## Repository Pattern
+
+`backend/db/repository.go` defines one Go interface per aggregate (`DeviceRepository`, `NetworkRepository`, `EventLogRepository`, `AlertRepository`, ...), each embedding the base `Repository` interface (`Close() error`). Concrete SQLite implementations live in `backend/db/sqlite_repositories.go`, `alert_repository.go`, and `geolocation_repository.go`. `db.RepositoryFactory` (constructed once in `main.go` from the open `*sql.DB`) hands out repository instances, services take a repository *interface*, never the factory or the raw `*sql.DB`, so they stay testable against `testutils.SetupTestDatabase`.
+
+Repositories take a `context.Context` as their first argument; most service methods above them do not thread a context through and instead call `context.Background()` or similar at the repository call site, match whatever the surrounding function already does rather than introducing a mix.
+
+## Alert Rules Pattern
+
+`backend/internal/alert/` is the clearest example of separating pure logic from I/O:
+
+- `rules.go`, pure functions (`evalUnidentifiedHosts`, `evalDuplicateMACs`, `evalRiskyPorts`, `evalHostUnreachable`) that take an `EvalInput` (in-memory snapshot of devices/networks) and return `[]Finding`. No database access, fully unit-testable (see `rules_test.go`).
+- `alert_service.go`, `AlertService.Evaluate` loads state through `DeviceReader`/`NetworkReader`, calls `EvaluateStateful`, and persists resulting `Finding`s as alert rows, deduplicating and expiring one-shot alerts.
+
+New alert rules should be added as another pure `eval*` function plus a case in `EvaluateStateful`, not folded into the service's I/O code.
+
+## Web Handler Pattern
+
+`WebHandler` (backend/internal/web/handlers.go) holds references to every service and is the only place that constructs HTTP responses:
+
+- Page routes call `h.ServePage("name")`, which renders `backend/assets/templates/index.html` (a single template selecting content by page name) against the embedded template FS.
+- `/api/*` routes are one method per endpoint, e.g. `APIUpdateDevice`, `APIScanStart`. They: pull the session via `h.sessionStore.Get(r, "reconya-session")`, resolve the user with `h.getUserFromSession(session)` and return 401 if nil, do minimal request parsing, call into a service, and write JSON with `json.NewEncoder(w).Encode(...)`.
+- Anything slow (a port scan, a rescan) is kicked off with `go h.someService.Run(...)` and the handler returns immediately with a "queued" response; the frontend polls for the result rather than the request blocking on it. Follow this pattern for any new handler that triggers scanning work.
+
+## Frontend (HTMX) Pattern
+
+There is no JS framework and no build step. `backend/assets/static/js/*.js` are small, page-scoped vanilla JS files (`devices.js`, `alerts.js`, `network-viz.js`, `scan-control.js`, ...) that call the `/api/*` endpoints (`fetch`) and patch the DOM, plus HTMX attributes in the templates for simple swap-on-response cases. When adding a UI feature, prefer an HTMX attribute on the element for simple fetch-and-swap; reach for a new/extended JS file only when you need client-side state (e.g. the topology map, scan control polling).

--- a/docs/code-conventions.md
+++ b/docs/code-conventions.md
@@ -1,0 +1,40 @@
+# Code Conventions
+
+## Language
+
+Backend is 100% Go. Frontend is server-rendered `html/template` plus small vanilla JS files and HTMX attributes, no TypeScript, no JS framework, no bundler.
+
+## Go Style
+
+- Standard `gofmt`/`go vet` formatting; run both before committing.
+- Errors are wrapped with `fmt.Errorf("...: %w", err)` at each layer boundary (repository → service → handler) so context accumulates without losing the original error for `errors.Is`/`errors.As`.
+- Sentinel errors are package-level vars, e.g. `db.ErrNotFound` in `backend/db/repository.go`.
+- Constructors are `New<Type>(...)` returning `*Type`, taking dependencies as explicit arguments (see [backend-patterns.md](backend-patterns.md)), no DI framework, no globals for services.
+- Enum-like values are typed string constants (e.g. `models.DeviceStatus`, `models.DeviceType` in `backend/models/device.go`), not raw strings or `iota` ints, keeps JSON output and SQL storage human-readable.
+- Background loops (goroutines started in `cmd/main.go`) each wrap their body in a `defer recover()` and log rather than propagate, a bug in one periodic task must not take down the process. Follow this pattern for any new long-running goroutine.
+
+## Comments
+
+Comments in this codebase explain *why*, not *what*, see the header comments on `runDeviceUpdater`, `runAlertEvaluator`, and the `alerts` table definition in `sqlite.go` for the expected tone: they call out a non-obvious constraint or a past bug, not a restatement of the code. Prefer no comment over one that just narrates the following line.
+
+## Models
+
+`backend/models/*.go` are plain structs shared across the repository, service, and handler layers, no separate DTOs. Struct tags carry `json:"..."` for API responses; many structs also still carry `bson:"..."` tags left over from a prior MongoDB-backed version. The `bson` tags are vestigial, the database is SQLite-only now (see [database.md](database.md)), don't treat their presence as a sign MongoDB is in use, and no need to keep adding them to new fields.
+
+## Naming
+
+- Packages: short, lowercase, no underscores (`pingsweep`, `nicidentifier`, `eventlog`).
+- Files within a package: `<name>_service.go`, `<name>_handlers.go`, `<name>_repository.go`, `<name>_test.go`.
+- IDs are UUIDs (`github.com/google/uuid`), stored as `TEXT PRIMARY KEY`, routes constrain the `{id}` path variable with the UUID regex (see `router.go`), so don't switch any resource to an integer/auto-increment ID without updating those route patterns.
+
+## API Conventions
+
+- All `/api/*` routes require an authenticated session (`h.getUserFromSession`), returning `401` if absent, mutating handlers check this explicitly at the top of the function rather than through middleware.
+- JSON responses are written by hand with `json.NewEncoder(w).Encode(...)`, not a shared response-envelope helper; match the shape already used by sibling endpoints in the same handler file rather than inventing a new envelope.
+- Long-running actions (scans) return immediately with a "queued" acknowledgment and do the work in a `go` goroutine, see [backend-patterns.md](backend-patterns.md#web-handler-pattern).
+
+## Frontend
+
+- Templates: single `index.html` selecting content by page name, plus `standalone/login.html`. Keep new pages inside this pattern rather than introducing a second template entrypoint.
+- Static JS is page-scoped, one file per concern (`devices.js`, `alerts.js`, `scan-control.js`, `network-viz.js`, ...) under `backend/assets/static/js/`. No shared JS framework/state store, DOM manipulation and `fetch` calls are direct.
+- CSS lives in one file, `backend/assets/static/css/console.css`.

--- a/docs/common-tasks.md
+++ b/docs/common-tasks.md
@@ -1,0 +1,57 @@
+# Common Tasks
+
+Concrete recipes. Background/rationale for each is in the linked doc.
+
+## Add a Column to an Existing Table
+
+1. Add `ALTER TABLE <table> ADD COLUMN <name> <type>` to the end of `db.InitializeSchema` (`backend/db/sqlite.go`), following the existing `log.Printf("Note: ... might already exist: %v", err)` pattern, do not touch the original `CREATE TABLE` block.
+2. Add the field to the matching struct in `backend/models/`.
+3. Update the repository's scan/insert SQL in `backend/db/sqlite_repositories.go` (or wherever that table's queries live) to read/write the new column.
+4. See [database.md](database.md).
+
+## Add a New Table
+
+1. Add a `CREATE TABLE IF NOT EXISTS` block (plus its indexes) to `db.InitializeSchema`.
+2. Add the repository interface to `backend/db/repository.go` and its SQLite implementation (new file `backend/db/<name>_repository.go`, following `alert_repository.go`).
+3. Add the corresponding struct to `backend/models/`.
+4. Wire a repository instance through `db.RepositoryFactory` in `cmd/main.go` if a service needs it.
+
+## Add a New Domain Module
+
+See [backend-patterns.md](backend-patterns.md#adding-a-new-module) for the full checklist: service file → repository (if needed) → wire into `cmd/main.go` → handlers/routes (if user-facing) → background goroutine (if periodic).
+
+## Add a New API Endpoint
+
+1. Add a handler method on `WebHandler` in `backend/internal/web/handlers.go` (or a new `<name>_handlers.go`, see `alert_handlers.go`).
+2. Check auth at the top: `session, _ := h.sessionStore.Get(r, "reconya-session"); user := h.getUserFromSession(session)`, `401` if nil (skip for read-only endpoints only if every sibling read endpoint in that file also skips it, check first).
+3. Register the route in `backend/internal/web/router.go`, under the `/api` subrouter. If the route takes a resource ID, use the existing UUID regex pattern from a neighboring route.
+4. If the work is slow (a scan), kick it off with `go` and return a "queued" response immediately.
+
+## Add a New Alert Rule
+
+1. Add a pure `eval<Name>(in EvalInput) []Finding` function to `backend/internal/alert/rules.go`.
+2. Add a case for it in `EvaluateStateful`.
+3. Give each `Finding` a `DedupeKey` that's stable across repeated evaluations of the same condition (rule id + device/network id + whatever varies), this is the upsert key in the `alerts` table, see [database.md](database.md#alerts-upsert-pattern).
+4. Add test cases to `rules_test.go`, no database needed, `eval*` functions are pure.
+
+## Add a New Page
+
+1. Add a route in `router.go`: `r.HandleFunc("/newpage", h.ServePage("newpage")).Methods("GET")`.
+2. Add the page's content block to `backend/assets/templates/index.html` following the existing page-name-selected pattern.
+3. Add a page-scoped JS file under `backend/assets/static/js/` if it needs client-side behavior, and/or HTMX attributes for simple fetch-and-swap interactions.
+
+## Add a New Config/Env Var
+
+1. Add the field to `config.Config` in `backend/internal/config/config.go`.
+2. Read it in `LoadConfig()` using `envBool`/`envInt`/`os.Getenv` per the existing helpers, with a safe default (see [architecture.md](architecture.md#network-isolation) if it enables any outbound network call, those must default to `false`).
+3. Document it in the README's Configuration section.
+
+## Fix a Bug
+
+1. Reproduce with a test first where practical (unit test in `rules_test.go`/model tests for pure logic, integration test in `backend/tests/integration/` if it needs the DB or a handler).
+2. Fix.
+3. `cd backend && go test ./...` and `go vet ./...`.
+
+## Cut a Release
+
+See [development-workflow.md](development-workflow.md#building-a-release-binary): `make release V=x.y.z`, then push the branch and the tag, `.github/workflows/release.yml` builds and publishes binaries for the tag.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,48 @@
+# Database
+
+SQLite only (`mattn/go-sqlite3`, cgo). No other database backend is supported: `internal/config.DatabaseType` has a single value, `SQLite`.
+
+## Connection
+
+`db.ConnectToSQLite` (backend/db/sqlite.go) opens the DB with WAL journaling and a set of concurrency-tuned pragmas (`busy_timeout=30000`, `synchronous=NORMAL`, `foreign_keys=ON`, `mmap_size=256MB`). Path comes from `SQLITE_PATH` (default `data/<DATABASE_NAME>.db`).
+
+## Schema: no migration files
+
+There is no `migrations/` directory and no migration runner. `db.InitializeSchema(db *sql.DB)` is called once at startup (`cmd/main.go`) and is the entire schema definition:
+
+1. Each table is created with `CREATE TABLE IF NOT EXISTS ...`, safe to re-run, no-op if the table exists.
+2. Columns added after a table's initial release are appended with `ALTER TABLE ... ADD COLUMN ...`, each wrapped so a "duplicate column" error (the column already exists on upgrade) is logged and ignored rather than treated as fatal.
+3. Indexes are `CREATE INDEX IF NOT EXISTS`.
+
+**To add a column:** append an `ALTER TABLE <table> ADD COLUMN <name> <type>` call at the end of `InitializeSchema`, following the existing `log.Printf("Note: ... might already exist: %v", err)` pattern, do not edit the original `CREATE TABLE` block, since that only runs on a brand-new database and existing installs would never get the column.
+
+**To add a table:** add a new `CREATE TABLE IF NOT EXISTS` block (see `alerts` or `web_services` for a fully-worked example including its indexes), then add the corresponding repository interface method(s) in `backend/db/repository.go` and implementation in `backend/db/sqlite_repositories.go` (or a new `<name>_repository.go` file, following `alert_repository.go`).
+
+There is no down-migration or rollback path: this is an intentionally append-only, backward-compatible schema evolution strategy suited to a single-file embedded database with no deploy pipeline.
+
+## Tables
+
+| Table | Purpose |
+|---|---|
+| `networks` | CIDR ranges the app knows about; `status`, `device_count`, `last_scanned_at` are denormalized for the networks page |
+| `devices` | One row per discovered host: identity (IPv4/MAC/vendor/hostname), status, OS fingerprint fields, IPv6 addresses, scan timestamps. `ipv4` is uniquely indexed |
+| `ports` | Open ports found on a device (`device_id` FK), one row per port |
+| `event_logs` | Append-only activity feed (status transitions, scan events); indexed on `created_at DESC` since the UI always reads "latest N" |
+| `system_status` | Single-row-ish table: detected NIC, selected/preselected network, cached public IP |
+| `local_devices` | The local machine's own interface info, one row keyed to `system_status` |
+| `web_services` | HTTP(S) services found on scanned ports, with optional screenshot path |
+| `geolocation_cache` | Cached IP → geo lookups, TTL'd via `expires_at` and swept by the cleanup goroutine |
+| `settings` | Single-row-per-user app settings (currently just `screenshots_enabled`) |
+| `alerts` | Alert/finding rows. `dedupe_key` is `UNIQUE` and is the upsert target, see below |
+
+## Alerts upsert pattern
+
+Alert rules re-evaluate the *entire* current state on every pass (see [backend-patterns.md](backend-patterns.md#alert-rules-pattern)) and re-emit the full finding set rather than diffing against what's already stored. Writes go through `INSERT ... ON CONFLICT(dedupe_key) DO UPDATE` so a still-active finding bumps `occurrences`/`last_seen_at` in place instead of creating duplicate rows. If you add a new alert rule, its `Finding.DedupeKey` must be stable across re-evaluations of the same underlying condition (e.g. derived from rule id + device id + port), or you'll get one row per evaluation tick instead of one row per finding.
+
+## Repository Layer
+
+See [backend-patterns.md](backend-patterns.md#repository-pattern) for how services consume repositories. In short: interface in `repository.go`, SQLite implementation in `sqlite_repositories.go` / `alert_repository.go` / `geolocation_repository.go`, all handed out by `db.RepositoryFactory`.
+
+## Testing against a real database
+
+Tests do not mock the database. `backend/tests/testutils/database.go`'s `SetupTestDatabase(t)` opens a throwaway SQLite file in `t.TempDir()`, runs the real `db.InitializeSchema`, and returns a cleanup func, so integration tests exercise actual SQL, not a fake. See [testing.md](testing.md).

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,0 +1,86 @@
+# Development Workflow
+
+## Initial Setup
+
+```bash
+git clone https://github.com/Dyneteq/reconya.git
+cd reconya
+make install     # creates backend/.env (admin/password default) and runs `go mod download && go mod tidy`
+```
+
+Requires Go 1.25+, a C compiler (cgo, for `mattn/go-sqlite3`), and `make`. On Windows, run with `CGO_ENABLED=1` and have TDM-GCC or MSVC Build Tools installed.
+
+## Running Locally
+
+```bash
+make start-dev   # foreground, logs to stdout, Ctrl+C to stop, use this while developing
+make start       # background daemon, logs to logs/reconya.log
+make stop        # stop the daemon
+make status      # check whether the daemon is running
+make logs        # dump daemon log
+make logs-follow # tail -f the daemon log
+make logs-errors # dump the error log
+```
+
+Both `start` and `start-dev` run `go run` directly (no separate build step needed for day-to-day work) and inject the version via `-ldflags -X reconya/assets.Version=$(VERSION)`, where `VERSION` comes from the root `VERSION` file.
+
+Equivalent manual invocation, if you want to skip the Makefile:
+
+```bash
+cd backend
+go run -ldflags "-X reconya/assets.Version=dev" ./cmd
+```
+
+The server listens on `PORT` (default `3008`, i.e. http://localhost:3008), and logs in with `LOGIN_USERNAME` / `LOGIN_PASSWORD` from `backend/.env`.
+
+Because there's no separate frontend build, editing anything under `backend/assets/templates/` or `backend/assets/static/` takes effect on the next request after a process restart (templates/static are embedded at compile time via `//go:embed`, not hot-reloaded), `go run` under `start-dev` recompiles on every restart, so just Ctrl+C and rerun after a template/JS change.
+
+## Environment Variables
+
+Set in `backend/.env` (see README for the full list). The ones that matter for development:
+
+| Var | Default | Notes |
+|---|---|---|
+| `LOGIN_USERNAME` / `LOGIN_PASSWORD` | required, no default | single-user login |
+| `DATABASE_NAME` | required, no default | also used to derive the default SQLite filename |
+| `SQLITE_PATH` | `data/<DATABASE_NAME>.db` | |
+| `PORT` | `3008` | |
+| `PUBLIC_IP_LOOKUP_ENABLED`, `GEOLOCATION_ENABLED`, `VENDOR_LOOKUP_ONLINE_ENABLED`, `OUI_DOWNLOAD_ENABLED` | all `false` | opt-in outbound calls, see [architecture.md](architecture.md#network-isolation) |
+| `ALERT_OFFLINE_THRESHOLD_HOURS` | `6` | how long a device must be unreachable before `host_unreachable` fires |
+| `IPV6_MONITORING_ENABLED` and related `IPV6_*` vars | see README | passive IPv6 discovery tuning |
+
+Network scanning (ICMP/ARP) generally needs elevated privileges, the built binary is typically run with `sudo`; `go run`/`make start-dev` may need it too depending on your OS.
+
+## Adding a Feature: Typical Walkthrough
+
+1. Decide whether it's a new module (`backend/internal/<name>/`) or belongs in an existing one, see [backend-patterns.md](backend-patterns.md).
+2. Add/modify the schema in `backend/db/sqlite.go` if it needs persistence, see [database.md](database.md).
+3. Add repository interface + implementation if needed.
+4. Implement the service.
+5. Wire the service into `backend/cmd/main.go`.
+6. Add handler methods + routes in `backend/internal/web/` if it's user-facing.
+7. Add/update templates and static JS if it needs UI.
+8. Write tests, see [testing.md](testing.md).
+9. `cd backend && go build ./...` and `go vet ./...` before committing.
+
+## Building a Release Binary
+
+```bash
+make build       # backend/reconya, CGO_ENABLED=1, version-stamped
+```
+
+Actual release binaries for Linux/macOS (amd64+arm64) are produced by `.github/workflows/release.yml`, triggered by pushing a `vX.Y.Z` tag:
+
+```bash
+make release V=x.y.z    # runs scripts/bump-version.sh: bumps VERSION, commits, tags
+git push origin <branch> vx.y.z
+```
+
+## Other Useful Commands
+
+```bash
+make deps             # go mod download && go mod tidy
+make clean            # go clean + remove built binary and pid file
+make prune-phantoms   # delete stale offline-device rows with no corroborating data (dry-run by default, CONFIRM=1 to apply)
+make help             # full command list
+```

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -1,0 +1,66 @@
+# Directory Structure
+
+Only git-tracked paths are listed. `data/`, `logs/`, `reconya/`, `oui/`, `src/`, and the `*.db*` files at the repo root are local runtime artifacts (gitignored) left behind by `make start` / manual `go run`, they are not part of the source tree and can be ignored or deleted freely.
+
+```
+reconya/
+├── backend/                      # Everything that ships in the binary
+│   ├── cmd/main.go               # Entry point: wiring, background workers, HTTP server
+│   ├── assets/
+│   │   ├── assets.go             # go:embed directives (templates, static, version)
+│   │   ├── templates/            # html/template source (index.html + standalone/login.html)
+│   │   └── static/{css,js}/      # Console CSS/JS, embedded and served at /static/
+│   ├── db/                       # SQLite connection, schema, repository implementations
+│   │   ├── sqlite.go             # ConnectToSQLite, InitializeSchema (CREATE TABLE IF NOT EXISTS)
+│   │   ├── repository.go         # Repository interfaces + RepositoryFactory
+│   │   ├── sqlite_repositories.go
+│   │   ├── alert_repository.go
+│   │   ├── geolocation_repository.go
+│   │   └── db_manager.go
+│   ├── internal/                 # Domain packages, one per concern (see backend-patterns.md)
+│   │   ├── alert/                # Alert rules: new device, risky port, unreachable, duplicate MAC...
+│   │   ├── config/                # Env-var driven Config, network-isolation flags
+│   │   ├── device/                # Device CRUD, status aging (online/idle/offline)
+│   │   ├── eventlog/               # Append-only activity log
+│   │   ├── fingerprint/            # OS/device-type fingerprinting from scan signals
+│   │   ├── ipv6monitor/            # Passive IPv6 neighbor discovery
+│   │   ├── network/                # Network (CIDR) CRUD and selection
+│   │   ├── nicidentifier/          # Primary NIC detection, new-network suggestions
+│   │   ├── oui/                     # MAC vendor lookup (bundled OUI DB, optional online refresh)
+│   │   ├── pingsweep/               # ICMP/TCP/ARP sweep implementation
+│   │   ├── portscan/                # Background port scanning + service/banner detection
+│   │   ├── scan/                    # ScanManager: orchestrates sweeps, IPv6 monitor, alert eval
+│   │   ├── scanner/                 # Low-level scan primitives shared by pingsweep/portscan
+│   │   ├── settings/                # User-configurable settings (single row)
+│   │   ├── systemstatus/            # Single-row status: detected NIC, selected network, geo cache
+│   │   ├── util/                     # Shared helpers
+│   │   ├── web/                      # WebHandler: routes, page rendering, /api/* handlers
+│   │   └── webservice/                # Web-service (HTTP port) screenshot capture
+│   ├── middleware/                 # LoggingMiddleware, CORS
+│   ├── models/                     # Plain structs shared across layers (Device, Network, Alert, ...)
+│   └── tests/
+│       ├── integration/            # DB-backed handler/service/repository tests
+│       ├── testutils/               # SetupTestDatabase, fixtures, HTTP test helpers
+│       └── config/test.env
+├── scripts/                        # Shell helpers invoked by the Makefile (start/stop/status/seed/bump-version)
+├── .github/workflows/               # test.yml (go test ./... on PRs), release.yml (tag-triggered builds)
+├── Makefile                         # make start/start-dev/stop/status/logs/build/release/help
+├── install.sh                       # curl-pipe installer for pre-built binaries
+├── VERSION                          # Plain-text version, injected via -ldflags at build time
+├── index.html / CNAME               # GitHub Pages marketing landing page (reconya.com), not the app
+└── screenshots/                     # README assets
+```
+
+## Critical Paths Quick Reference
+
+| Task | Location |
+|---|---|
+| Add a new domain feature | `backend/internal/<feature>/` |
+| Add/modify an API or page route | `backend/internal/web/router.go` + `handlers.go` |
+| Change the DB schema | `backend/db/sqlite.go` (`InitializeSchema`) |
+| Add/modify a repository method | `backend/db/repository.go` (interface) + `backend/db/sqlite_repositories.go` (impl) |
+| Add a shared data type | `backend/models/` |
+| Change background worker behavior | `backend/cmd/main.go` |
+| Console frontend (HTML/CSS/JS) | `backend/assets/templates/`, `backend/assets/static/{css,js}/` |
+| Add an env-configurable setting | `backend/internal/config/config.go` |
+| Add a test | `backend/tests/integration/` or a `_test.go` next to the code it covers |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,51 @@
+# Testing
+
+## Framework
+
+Standard `testing` package + `testify` (`assert`/`require`). No mocking framework, tests that need a database use a real, throwaway SQLite instance.
+
+## Layout
+
+Two patterns coexist:
+
+- **Colocated unit tests**, `<file>_test.go` next to the code it covers, `package <same as prod code>`. Used for pure-logic packages: `backend/internal/alert/rules_test.go`, `backend/internal/scanner/onlink_test.go`, `backend/internal/webservice/screenshot_fallback_test.go`, `backend/internal/web/template_funcs_test.go`, `backend/models/device_test.go`.
+- **Integration tests**, `backend/tests/integration/`, `package integration`, exercising repositories/services/handlers against a real SQLite database: `device_service_test.go`, `device_handlers_test.go`, `alert_repository_test.go`, `shared_test.go` (shared fixtures/helpers for that package).
+
+When adding a test for pure logic (no DB, no HTTP), colocate it. When it needs the database or a handler round-trip, put it in `backend/tests/integration/`.
+
+## Test Database
+
+`backend/tests/testutils/database.go`:
+
+```go
+testDB, cleanup := testutils.SetupTestDatabase(t)        // real SQLite file in t.TempDir(), schema via db.InitializeSchema
+defer cleanup()
+
+factory, cleanup := testutils.SetupTestRepositoryFactory(t)  // same, wrapped in a RepositoryFactory
+defer cleanup()
+```
+
+`testutils.GetTestConfig()` returns a `*config.Config` stub for services that need one. `backend/tests/testutils/fixtures.go` has builders like `CreateTestDevice()`, `CreateTestDeviceWithIP(ip)`, `CreateTestNetwork()`, prefer these over hand-rolling structs so tests stay consistent as models grow fields. `backend/tests/testutils/http.go` has HTTP test helpers for handler tests.
+
+## Pattern
+
+Arrange-Act-Assert, using `t.Run` subtests to group related cases under one setup (see `device_service_test.go`, `alert_repository_test.go`). Prefer `require` for setup/precondition checks that should abort the test immediately on failure, `assert` for the actual expectations so multiple assertions in one subtest all get reported.
+
+## Running Tests
+
+```bash
+cd backend
+go test ./...                    # everything
+go test ./internal/alert/...     # one package
+go test -run TestDeviceRepository_Integration ./tests/integration/...
+go test -v ./...                 # verbose
+```
+
+CI (`.github/workflows/test.yml`) runs `go test ./...` with `CGO_ENABLED=1` on every PR to `master`, the cgo SQLite driver requires this locally too.
+
+## What to Test
+
+- New alert rules: add cases to `rules_test.go` covering the pure `eval*` function directly, no database needed.
+- New repository methods: add an integration test in `backend/tests/integration/` using `SetupTestRepositoryFactory`.
+- New handlers: follow `device_handlers_test.go` for the request/response round-trip pattern.
+- Bug fixes: reproduce with a failing test first where practical, then fix.


### PR DESCRIPTION
## Summary
- Networks can now own several CIDR ranges instead of exactly one, so scans target the real subnets in use instead of a covering supernet (schema, repository, service, and scan pipeline all updated; ranges live in a new `network_ranges` table with a backfill migration for existing single-CIDR networks)
- Each range can be toggled in or out of the scan plan independently, without losing its scan history (deactivate rather than delete)
- `/networks` page now has a repeatable range-row form (CIDR + optional label per row) instead of a single CIDR input
- Dashboard's old "SUBNET LOAD" panel is now "SCAN PLAN": a per-range segment tile row (click to filter the device dock by range) plus a detail list showing real per-range address capacity, known/online counts, and a running total across active ranges, with click-to-toggle

## Test plan
- [x] `go build ./...` and `go vet ./...`
- [x] `go test ./...` (full suite, including new unit tests for the model, service, and scan-merge/dedupe logic)
- [x] Smoke-tested the running server against a throwaway database: logged in, created a two-range network, toggled a range off, edited it to drop one range and add another, confirmed the dropped range was deactivated (not deleted) and kept its history, verified all pages and static JS assets serve correctly
- [x] Verified the backfill migration against a simulated legacy single-CIDR network row

Fixes #136