### PR TITLE
Fix panic on repeated scan stop (close of closed channel)

### DIFF
--- a/backend/internal/ipv6monitor/ipv6_monitor_service.go
+++ b/backend/internal/ipv6monitor/ipv6_monitor_service.go
@@ -58,19 +58,14 @@ type IPv6Address struct {
 }
 
 func NewIPv6MonitorService(deviceService *device.DeviceService, networkService *network.NetworkService, logger *log.Logger) *IPv6MonitorService {
-	ctx, cancel := context.WithCancel(context.Background())
-	
 	return &IPv6MonitorService{
 		deviceService:     deviceService,
 		networkService:    networkService,
 		logger:           logger,
-		ctx:              ctx,
-		cancel:           cancel,
 		monitorInterfaces: []string{}, // Will be auto-detected
 		hostPrefixes:     []string{},  // Will be auto-detected
 		linkLocalEnabled: true,
 		multicastEnabled: true,
-		deviceChan:       make(chan IPv6Device, 100),
 	}
 }
 
@@ -83,12 +78,19 @@ func (s *IPv6MonitorService) Start() error {
 	}
 	
 	s.logger.Println("Starting IPv6 passive monitoring service...")
-	
+
 	// Auto-detect network interfaces and prefixes
 	if err := s.detectNetworkConfiguration(); err != nil {
 		return fmt.Errorf("failed to detect network configuration: %w", err)
 	}
-	
+
+	// Create a fresh context and device channel for this run. Stop() cancels
+	// the context and closes the channel, so both must be recreated here to
+	// support repeated start/stop cycles without reusing an already-closed
+	// channel or an already-cancelled context.
+	s.ctx, s.cancel = context.WithCancel(context.Background())
+	s.deviceChan = make(chan IPv6Device, 100)
+
 	s.isRunning = true
 	
 	// Start device processing worker

--- a/backend/internal/ipv6monitor/ipv6_monitor_service_test.go
+++ b/backend/internal/ipv6monitor/ipv6_monitor_service_test.go
@@ -1,0 +1,36 @@
+package ipv6monitor
+
+import (
+	"log"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStartStopCycle reproduces the crash from issue #143: stopping a scan
+// closed the IPv6 monitor's device channel and cancelled its context
+// permanently, so a subsequent start/stop cycle panicked on "close of closed
+// channel". Start() must hand each run a fresh channel and context.
+func TestStartStopCycle(t *testing.T) {
+	logger := log.Default()
+	svc := NewIPv6MonitorService(nil, nil, logger)
+
+	require.NoError(t, svc.Start())
+	assert.True(t, svc.IsRunning())
+	require.NoError(t, svc.Stop())
+	assert.False(t, svc.IsRunning())
+
+	// Second cycle must not panic (close of already-closed channel) and must
+	// not exit its goroutines immediately (already-cancelled context).
+	require.NoError(t, svc.Start())
+	assert.True(t, svc.IsRunning())
+	require.NoError(t, svc.Stop())
+	assert.False(t, svc.IsRunning())
+}
+
+// TestStopWhenNotRunning must be a no-op, not a panic.
+func TestStopWhenNotRunning(t *testing.T) {
+	svc := NewIPv6MonitorService(nil, nil, log.Default())
+	require.NoError(t, svc.Stop())
+}


### PR DESCRIPTION
## Problem

Stopping a scan crashed the whole app with:

```
panic: close of closed channel
reconya/internal/ipv6monitor.(*IPv6MonitorService).Stop(...)
	reconya/internal/ipv6monitor/ipv6_monitor_service.go:130
```

`IPv6MonitorService` created its context (`ctx`/`cancel`) and `deviceChan` once, in the constructor. `Stop()` cancels the context and closes the channel, but `Start()` never recreated either for the next run. On a second start/stop cycle, `Stop()` closed the already-closed channel, panicking the process (and, separately, would have restarted goroutines against an already-cancelled context, silently killing IPv6 monitoring on the second start).

## Fix

`Start()` now creates a fresh `context.Context`/`CancelFunc` and `deviceChan` on every run, so each start/stop cycle gets its own channel and context instead of reusing ones already torn down by a previous `Stop()`.

## Testing

Added `TestStartStopCycle`, which runs two start/stop cycles back to back. It reproduces the exact panic from the issue against the old code and passes against the fix. Also added `TestStopWhenNotRunning` for the no-op case.

```
go test ./internal/ipv6monitor/... -v
go test ./...
```

Fixes #143